### PR TITLE
only apply etag rules to doc paths

### DIFF
--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor.cljc
@@ -197,7 +197,7 @@
 ;; TODO: stop using this in favor of only applying the etag interceptor to doc
 ;; routes
 
-(defn- etag-route?
+(defn etag-route?
   [req-uri]
   (some #(.endsWith #?(:cljs req-uri
                        :clj ^String req-uri)


### PR DESCRIPTION
Don't generate or check etags if it isn't in `/activities/state`, `/activities/profile` or `/agents/profile`