### PR TITLE
LRS-31 Dont require returned attachments for multipart return on sync

### DIFF
--- a/src/main/com/yetanalytics/lrs/pedestal/routes/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/statements.cljc
@@ -156,8 +156,7 @@
       (try (assoc ctx
                   :response
                   (if-let [s-data (or statement statement-result)]
-                    (if (and (get-in xapi [:xapi.statements.GET.request/params :attachments])
-                             (seq attachments))
+                    (if (get-in xapi [:xapi.statements.GET.request/params :attachments])
                       {:status 200
                        :headers (cond-> {"Content-Type" att-resp/content-type}
                                   etag (assoc "etag" etag))


### PR DESCRIPTION
Fixes [LRS-31] by standardizing logic between sync/async statements GET handling

[LRS-31]: https://yet.atlassian.net/browse/LRS-31