### PR TITLE
LRS-34 Inline truncation "bubble wrap"

### DIFF
--- a/resources/lrs/statements/style.css
+++ b/resources/lrs/statements/style.css
@@ -80,7 +80,6 @@ main.statement {
   padding: 1em;
 }
 
-
 /* leaf inner */
 .json-scalar {
   text-overflow: ellipsis;

--- a/src/main/com/yetanalytics/lrs/pedestal/routes/statements/html/json.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/statements/html/json.cljc
@@ -12,7 +12,9 @@
   "is the string link-like?"
   [^String maybe-link]
   (or (.startsWith maybe-link "http://")
-      (.startsWith maybe-link "https://")))
+      (.startsWith maybe-link "https://")
+      (.startsWith maybe-link "/") ;; catch more link
+      ))
 
 (defn json-map-entry
   "Helper for creating map entries"


### PR DESCRIPTION
Simple inline truncation inputs let you peek at the first thing in a list or map, and then opt to disclose the rest

Rendering on statements page:
![image](https://user-images.githubusercontent.com/782173/124000893-0fec3600-d9a2-11eb-9620-56c3cefe3b58.png)
