### PR TITLE
Debug 401/403 responses

### DIFF
--- a/src/main/com/yetanalytics/lrs/impl/memory.cljc
+++ b/src/main/com/yetanalytics/lrs/impl/memory.cljc
@@ -789,12 +789,19 @@
       (-authenticate [lrs ctx]
         ;; Authenticate is a no-op right now, just returns a dummy
         {:result
-         {:scopes #{:scope/all}
-          :prefix ""
-          :auth {:no-op {}}}})
+         (if (some-> ctx
+                     :request
+                     :headers
+                     (get "authorization")
+                     ;; username:password
+                     (= "Basic dXNlcm5hbWU6cGFzc3dvcmQ="))
+           {:scopes #{:scope/all}
+            :prefix ""
+            :auth {:no-op {}}}
+           :com.yetanalytics.lrs.auth/unauthorized)})
       (-authorize [lrs ctx auth-identity]
         ;; Auth
-        {:result true})
+        {:result (some? auth-identity)})
       p/LRSAuthAsync
       (-authenticate-async [lrs ctx]
         (a/go (p/-authenticate lrs ctx)))


### PR DESCRIPTION
In lrsql we're getting weird responses (403) when no headers are provided. I think this is actually due to weird code in LRS. Attempt to reproduce LRSQL behavior in the mem lrs