### PR TITLE
LRS-34 use css for truncator label text for easier customizability

### DIFF
--- a/resources/lrs/statements/style.css
+++ b/resources/lrs/statements/style.css
@@ -143,6 +143,34 @@ label.truncator-label {
   padding: 1em;
 }
 
+.json-map > label.truncator-label::before {
+  display: contents;
+  content: "{ ";
+}
+
+.json-map > label.truncator-label::after {
+  display: contents;
+  content: " more entry }";
+}
+
+.json-map > label.truncator-label.plural::after {
+  content: " more entries }";
+}
+
+.json-array > label.truncator-label::before {
+  display: contents;
+  content: "[ ";
+}
+
+.json-array > label.truncator-label::after {
+  display: contents;
+  content: " more element ]";
+}
+
+.json-array > label.truncator-label.plural::after {
+  content: " more elements ]";
+}
+
 input.truncator ~ :not(.no-truncate,label.truncator-label) {
   display: none;
 }

--- a/src/main/com/yetanalytics/lrs/pedestal/routes/statements/html/json.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/statements/html/json.cljc
@@ -141,7 +141,8 @@
                   (if (not-empty rent)
                     (let [truncator-id (str
                                         #?(:clj (java.util.UUID/randomUUID)
-                                           :cljs (random-uuid)))]
+                                           :cljs (random-uuid)))
+                          rent-count (count rent)]
                       (-> [:div.json.json-map]
                           (into fent)
                           (into
@@ -149,9 +150,11 @@
                              {:type "checkbox"
                               :id truncator-id
                               :style "display:none;"}]
-                            [:label.truncator-label
+                            [(if (< 1 rent-count)
+                               :label.truncator-label.plural
+                               :label.truncator-label)
                              {:for truncator-id}
-                             (format "{ %d more }" (count rent))]])))
+                             (format "%d" (count rent))]])))
                     (into [:div.json.json-map] fent)))
                 (into
                  rent)
@@ -191,16 +194,19 @@
                     (if (not-empty rel)
                       (let [truncator-id (str
                                           #?(:clj (java.util.UUID/randomUUID)
-                                             :cljs (random-uuid)))]
+                                             :cljs (random-uuid)))
+                            rel-count (count rel)]
                         (-> [arr-k]
                             (into fel)
                             (into [[:input.truncator
                                     {:type "checkbox"
                                      :id truncator-id
                                      :style "display:none;"}]
-                                   [:label.truncator-label
+                                   [(if (< 1 rel-count)
+                                      :label.truncator-label.plural
+                                      :label.truncator-label)
                                     {:for truncator-id}
-                                    (format "[ %d more ]" (count rel))]])))
+                                    (format "%d" (count rel))]])))
                       (into [arr-k] fel)))
                   (into
                    rel)


### PR DESCRIPTION
[LRS-34]

This PR moves responsibility for the truncator label text (besides the number) to CSS. The aim is easier implementation, since the upstream rendering code cannot be changed.

Note that this may break upstream impls with their own CSS, hence asking for @cliffcaseyyet to take a look with the lrs admin console in mind.

[LRS-34]: https://yet.atlassian.net/browse/LRS-34