### PR TITLE
Set `related` to `true` when filtering

### DIFF
--- a/src/main/com/yetanalytics/lrs/pedestal/routes/statements/html.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/statements/html.cljc
@@ -135,7 +135,8 @@
                   path-prefix
                   (merge-params
                    url-params
-                   {:agent json}))}
+                   {:agent json
+                    :related_agents true}))}
              "Filter..."]]])))
 
 (defn verb-pred
@@ -189,7 +190,8 @@
                path-prefix
                (merge-params
                 url-params
-                {:activity (get json "id")}))}
+                {:activity (get json "id")
+                 :related_activities true}))}
              "Filter..."]]])))
 
 (defn reg-pred [path _json]


### PR DESCRIPTION
Before, when filtering on non-Actor agents or non-Object activities, the query would fail to retrieve statements correctly because `related_agents` and `related_activities`, respectively, were not set to `true`.

In this mini-PR, we set those two params to `true` automatically, even for Actor agents and Object activities. Partly because I'm not sure how to predicate on the agent/activity usage, but also because there may be cases where, for instance, an Object activity is also used as a Context activity in another statement. Thus, automatically setting `related` to `true` allows for maximum flexibility.