### PR TITLE
Latest xapi-schema with more permissive uuid regex

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
   org.clojure/clojurescript {:mvn/version "1.10.741"}
   org.clojure/core.async {:mvn/version "1.1.587"}
   com.yetanalytics/xapi-schema {:git/url "https://github.com/yetanalytics/xapi-schema.git"
-                                :sha "e2c517e7adcedc7f3012b90bce274e2c33cdbcc1"
+                                :sha "4b97122d839e895b9111e6ed62ae68bc0fdee723"
                                 :exclusions [org.clojure/clojurescript]}
   cheshire/cheshire {:mvn/version "5.10.0"}
   io.pedestal/pedestal.service {:mvn/version "0.5.7"}


### PR DESCRIPTION
Accommodate UUIDs like those generated by `colossal-squuid`