### PR TITLE
Split test and server build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ npm-debug.log
 package.json
 package-lock.json
 *.log
+/out_test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .phony: clean repl repl-cljs run-dev run-dev-cljs test-lib test-lib-cljs test-lib-clj test-conformance test-all ci
 
 clean:
-	rm -rf target pom.xml.asc logs out node_modules .cljs_node_repl package.json package-lock.json
+	rm -rf target pom.xml.asc logs out node_modules .cljs_node_repl package.json package-lock.json out_test
 
 node_modules:
 	clojure -Mdev -m cljs.main --install-deps
@@ -22,11 +22,11 @@ out/main.js: node_modules
 run-dev-cljs: out/main.js
 	node out/main.js
 
-out/test.js: node_modules
-	clojure -Mdev -m cljs.main -re node -d out -o "out/test.js" -t nodejs -O none -c com.yetanalytics.test-runner
+out_test/test.js: node_modules
+	clojure -Mdev -m cljs.main -re node -d out_test -o "out_test/test.js" -t nodejs -O none -c com.yetanalytics.test-runner
 
-test-lib-cljs: out/test.js
-	node out/test.js
+test-lib-cljs: out_test/test.js
+	node out_test/test.js
 
 test-lib-clj:
 	clojure -Mdev -m com.yetanalytics.test-runner


### PR DESCRIPTION
On `master`, if you do:

    make test-lib-cljs

And then:

    make run-dev-cljs

The second command will fail, because the build _overwrites_ some files it needs (since it has no optimizations applied). To fix this we add the `out_test` dir and put the test code there, no clash.

I'm pretty sure this has caused some wild CI errors, since the conformance tests expect a working cljs server to be ready to go.