### PR TITLE
Audit npm in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        target: [test-lib-clj, test-lib-cljs, test-conformance-clj-sync, test-conformance-clj-async, test-conformance-cljs]
+        target: [test-lib-clj, test-lib-cljs, test-conformance-clj-sync, test-conformance-clj-async, test-conformance-cljs, npm-audit]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.phony: clean repl repl-cljs run-dev run-dev-cljs test-lib test-lib-cljs test-lib-clj test-conformance test-conformance-clj-sync test-conformance-clj-async test-conformance-cljs test-all ci
+.phony: clean repl repl-cljs run-dev run-dev-cljs test-lib test-lib-cljs test-lib-clj test-conformance test-conformance-clj-sync test-conformance-clj-async test-conformance-cljs test-all ci npm-audit
 
 clean:
 	rm -rf target pom.xml.asc logs out node_modules .cljs_node_repl package.json out_test
@@ -46,4 +46,7 @@ test-conformance: test-conformance-clj-sync test-conformance-clj-async test-conf
 
 test-all: test-lib test-conformance
 
-ci: test-all
+npm-audit: node_modules
+	npm audit
+
+ci: npm-audit test-all


### PR DESCRIPTION
Dependabot is nice but we only get alerts when code hits master. Add `npm audit` to the CI workflow so it fails if any sec issues are detected!