### PR TITLE
Gh action improvement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,23 +9,10 @@ jobs:
         target: [test-lib-clj, test-lib-cljs, test-conformance-clj-sync, test-conformance-clj-async, test-conformance-cljs, npm-audit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Prepare Node
-        uses: actions/setup-node@v2
+      - name: yeti-ci
+        uses: yetanalytics/yeti-ci-action@v0
         with:
-          node-version: '14'
-
-      - name: Prepare java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@3.5
-        with:
-          cli: 1.10.3.943 # Clojure CLI based on tools.deps
+          enable-node: true
 
       - name: Run make target ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: yeti-ci
-        uses: yetanalytics/yeti-ci-action@v0
+        uses: yetanalytics/actions/setup-env@v0
 
       - name: Run make target ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
         target: [test-lib-clj, test-lib-cljs, test-conformance-clj-sync, test-conformance-clj-async, test-conformance-cljs, npm-audit]
     runs-on: ubuntu-latest
     steps:
-      - name: yeti-ci
+      - name: Setup CI Environment
         uses: yetanalytics/actions/setup-env@v0
 
       - name: Run make target ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: yeti-ci
         uses: yetanalytics/yeti-ci-action@v0
-        with:
-          enable-node: true
 
       - name: Run make target ${{ matrix.target }}
         run: make ${{ matrix.target }}


### PR DESCRIPTION
This shows a possible route to standardizing CI environments. Things like matrices and actual commands ~~should probably not~~ _can not_ live in the composite action, or at least the same one. But this centralizes default versions and removes a BUNCH of repeat code from our actions.

See https://github.com/yetanalytics/yeti-ci-action for the composite action code