### PR TITLE
Allow environment configuration of dev in-memory LRS bind host and port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Updated `ws` and `ansi-regex` for minor security vulnerabilitites
 - Standardized signed statement comparison with extant statement comparison
 - Fixed bug preventing attachments with duplicate SHAs
+- Allow environment configuration of dev in-memory LRS bind host and port
 
 ## [1.1.0] - 2021-09-22
 - Added `dissoc-statement-properties` and `statements-immut-equal?` in the `com.yetanalytics.lrs.xapi.statements` namespace, for dissoc-ing immutable Statement properties and comprehensive Statement equality checking, respectively.

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,9 +449,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
       "requires": {
         "has": "^1.0.3"
       }

--- a/src/dev/mem_lrs/server.cljc
+++ b/src/dev/mem_lrs/server.cljc
@@ -34,6 +34,11 @@
     (-> service/service ;; start with production configuration
         (merge {:env  :dev
                 ::lrs lrs
+                ::server/host (or (System/getenv "HTTP_HOST")
+                                  "0.0.0.0")
+                ::server/port (or (some-> (System/getenv "HTTP_PORT")
+                                          Long/parseLong)
+                                  8080)
                 ;; do not block thread that starts web server
                 ::server/join? false
                 ;; Routes can be a function that resolve routes,


### PR DESCRIPTION
Sometimes it is useful to control the port of the in-memory development LRS. This modifies the `run-dev` function to take `HTTP_HOST` and `HTTP_PORT` from environment.