### PR TITLE
Content-length and content-type are optional

### DIFF
--- a/src/main/com/yetanalytics/lrs/impl/memory.cljc
+++ b/src/main/com/yetanalytics/lrs/impl/memory.cljc
@@ -702,6 +702,13 @@
      ;; Itsa no-op
      :cljs contents))
 
+(defn init-document
+  [{:keys [contents content-type content-length]}]
+  (let [contents-bytes (contents->byte-array contents)]
+    {:contents contents-bytes
+     :content-type (or content-type "application/octet-stream")
+     :content-length (or content-length (count contents-bytes))}))
+
 (defn transact-document
   [documents params document merge?]
   (let [{:keys [context-key
@@ -709,7 +716,7 @@
                 document]}
         (document-keys
          params
-         (update document :contents contents->byte-array))
+         (init-document document))
         update-doc-fn
         (if merge?
           (update-in documents

--- a/src/main/com/yetanalytics/lrs/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/xapi/document.cljc
@@ -20,8 +20,9 @@
   string-ascii-not-empty)
 
 (s/def ::content-length
-  (s/int-in 0 #?(:clj Long/MAX_VALUE
-                 :cljs 9007199254740992)))
+  (s/nilable
+   (s/int-in 0 #?(:clj Long/MAX_VALUE
+                  :cljs 9007199254740992))))
 
 (s/def ::contents
   #?(:clj (s/with-gen

--- a/src/main/com/yetanalytics/lrs/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/xapi/document.cljc
@@ -17,12 +17,11 @@
   (timestamp/stamp-now))
 
 (s/def ::content-type
-  (s/nilable string-ascii-not-empty))
+  string-ascii-not-empty)
 
 (s/def ::content-length
-  (s/nilable
-   (s/int-in 0 #?(:clj Long/MAX_VALUE
-                  :cljs 9007199254740992))))
+  (s/int-in 0 #?(:clj Long/MAX_VALUE
+                 :cljs 9007199254740992)))
 
 (s/def ::contents
   #?(:clj (s/with-gen
@@ -81,11 +80,11 @@
 
 (s/def :com.yetanalytics.lrs.xapi/document
   (s/with-gen
-    (s/keys :req-un [::content-length
-                     ::content-type
-                     ::contents]
+    (s/keys :req-un [::contents]
             :opt-un [::id
-                     ::updated])
+                     ::updated
+                     ::content-length
+                     ::content-type])
     (fn []
       (sgen/one-of [(document-gen-fn)
                     (json-document-gen-fn)]))))

--- a/src/main/com/yetanalytics/lrs/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/xapi/document.cljc
@@ -17,7 +17,7 @@
   (timestamp/stamp-now))
 
 (s/def ::content-type
-  (s/nilable string?))
+  (s/nilable string-ascii-not-empty))
 
 (s/def ::content-length
   (s/nilable

--- a/src/main/com/yetanalytics/lrs/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/xapi/document.cljc
@@ -17,7 +17,7 @@
   (timestamp/stamp-now))
 
 (s/def ::content-type
-  string-ascii-not-empty)
+  (s/nilable string?))
 
 (s/def ::content-length
   (s/nilable


### PR DESCRIPTION
Update the content-length spec to reflect that it is nilable. 1.x says that the client [SHOULD* send it](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#header-parameters). ~~In 2.0 this should change to a MUST and the LRS should throw a 400 if no content-length is provided.~~

A client must _either_ send a `content-length` or `transfer-encoding: chunked` header. If they do the latter, the content length will not be known when the inputstream is passed to the impl. Additionally, the content-type may be left out of some documents so we pass this through to the impl.