### PR TITLE
LRS-60 change align-items from baseline to center for map entries

### DIFF
--- a/resources/lrs/statements/style.css
+++ b/resources/lrs/statements/style.css
@@ -61,7 +61,7 @@ body > main {
 .json-map-entry {
   display:grid;
   grid-template-columns: minmax(max-content, 9em) 1fr;
-  align-items: baseline;
+  align-items: center;
   border-bottom: #EBEBEB solid 0.1em;
 }
 


### PR DESCRIPTION
[LRS-60] Our use of `align-items: baseline;` causes a tab crash on Chrome 95+. Use `align-items: center;` to not crash the browser.

NOTE: For the benefit of anyone chasing down the chrome issue and finding this, please see a static reproduction here: https://github.com/yetanalytics/lrs_css_bug_repro

A live demo can be found here: https://yetanalytics.github.io/lrs_css_bug_repro/

Click on the "8" to expand, tab will crash!

[LRS-60]: https://yet.atlassian.net/browse/LRS-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ