### PR TITLE
LRS-61 Remove Error Interceptor

### DIFF
--- a/src/dev/mem_lrs/service.cljc
+++ b/src/dev/mem_lrs/service.cljc
@@ -2,10 +2,12 @@
   (:require [io.pedestal.http :as http]
             [com.yetanalytics.lrs.impl.memory :as lrs-impl :refer [new-lrs]]
             [com.yetanalytics.lrs.pedestal.routes :refer [build]]
+            [com.yetanalytics.lrs.pedestal.interceptor :as i]
             #?(:cljs [com.yetanalytics.node-chain-provider :as provider])))
 
 (defn new-routes [lrs]
-  (build {:lrs lrs}))
+  (build {:lrs lrs
+          :wrap-interceptors [i/error-interceptor]}))
 
 ;; Tabular routes + default LRS
 (def default-lrs

--- a/src/main/com/yetanalytics/lrs.cljc
+++ b/src/main/com/yetanalytics/lrs.cljc
@@ -1,5 +1,5 @@
 (ns com.yetanalytics.lrs
-  (:require [com.yetanalytics.lrs.protocol :as p]
+  (:require [com.yetanalytics.lrs.protocol :as p :include-macros true]
             [clojure.spec.alpha :as s :include-macros true]
             [xapi-schema.spec :as xs]
             [xapi-schema.spec.resources]
@@ -20,9 +20,8 @@
 (defn get-about
   "Get information about this LRS"
   [lrs auth-identity]
-  (try (p/-get-about lrs auth-identity)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-get-about lrs auth-identity)))
 
 (s/fdef get-about
   :args (s/cat :lrs           (with-lrs-gen ::p/about-resource-instance)
@@ -45,9 +44,8 @@
 
 (defn set-document
   [lrs auth-identity params document merge?]
-  (try (p/-set-document lrs auth-identity params document merge?)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-set-document lrs auth-identity params document merge?)))
 
 (s/fdef set-document
   :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -72,9 +70,8 @@
 
 (defn get-document
   [lrs auth-identity params]
-  (try (p/-get-document lrs auth-identity params)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-get-document lrs auth-identity params)))
 
 (s/fdef get-document
   :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -95,9 +92,8 @@
 
 (defn get-document-ids
   [lrs auth-identity params]
-  (try (p/-get-document-ids lrs auth-identity params)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-get-document-ids lrs auth-identity params)))
 
 (s/fdef get-document-ids
   :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -118,9 +114,8 @@
 
 (defn delete-document
   [lrs auth-identity params]
-  (try (p/-delete-document lrs auth-identity params)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-delete-document lrs auth-identity params)))
 
 (s/fdef delete-document
  :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -140,9 +135,8 @@
 
 (defn delete-documents
   [lrs auth-identity params]
-  (try (p/-delete-documents lrs auth-identity params)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-delete-documents lrs auth-identity params)))
 
 (s/fdef delete-documents
  :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -168,9 +162,8 @@
 (defn get-activity
   "Get the canonical representation of an activity"
   [lrs auth-identity params]
-  (try (p/-get-activity lrs auth-identity params)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-get-activity lrs auth-identity params)))
 
 (s/fdef get-activity
   :args (s/cat :lrs           (with-lrs-gen ::p/activity-info-resource-instance)
@@ -198,9 +191,8 @@
 (defn get-person
   "Get an object representing an actor"
   [lrs auth-identity params]
-  (try (p/-get-person lrs auth-identity params)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-get-person lrs auth-identity params)))
 
 (s/fdef get-person
   :args (s/cat :lrs           (with-lrs-gen ::p/agent-info-resource-instance)
@@ -230,9 +222,8 @@
 (defn store-statements
   "Store statements and attachments in the LRS"
   [lrs auth-identity statements attachments]
-  (try (p/-store-statements lrs auth-identity statements attachments)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-store-statements lrs auth-identity statements attachments)))
 
 (s/fdef store-statements
   :args (s/cat :lrs           (with-lrs-gen ::p/statements-resource-instance)
@@ -257,9 +248,8 @@
 (defn get-statements
   "Get statements from the LRS"
   [lrs auth-identity params ltags]
-  (try (p/-get-statements lrs auth-identity params ltags)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-get-statements lrs auth-identity params ltags)))
 
 (s/fdef get-statements
   :args (s/cat :lrs           (with-lrs-gen ::p/statements-resource-instance)
@@ -281,7 +271,6 @@
                :ltags         (s/coll-of ::xs/language-tag))
   :ret ::p/get-statements-async-ret)
 
-;; TODO: Figure out error strategy, maybe wrap return in map
 (defn consistent-through
   "Get a timestamp for use in the X-Experience-API-Consistent-Through header"
   [lrs ctx auth-identity]
@@ -312,9 +301,8 @@
 (defn authenticate
   "Given the LRS and context, return an identity or nil (401)"
   [lrs ctx]
-  (try (p/-authenticate lrs ctx)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-authenticate lrs ctx)))
 
 (s/fdef authenticate
   :args (s/cat :lrs (with-lrs-gen ::p/lrs-auth-instance)
@@ -325,9 +313,8 @@
   "Given the LRS and context, return true if the user is allowed to do a given
    thing."
   [lrs ctx auth-identity]
-  (try (p/-authorize lrs ctx auth-identity)
-       (catch #?(:clj Exception :cljs js/Error) ex
-         {:error ex})))
+  (p/try-sync
+   (p/-authorize lrs ctx auth-identity)))
 
 (s/fdef auth
   :args (s/cat :lrs           (with-lrs-gen ::p/lrs-auth-instance)

--- a/src/main/com/yetanalytics/lrs.cljc
+++ b/src/main/com/yetanalytics/lrs.cljc
@@ -20,7 +20,9 @@
 (defn get-about
   "Get information about this LRS"
   [lrs auth-identity]
-  (p/-get-about lrs auth-identity))
+  (try (p/-get-about lrs auth-identity)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef get-about
   :args (s/cat :lrs           (with-lrs-gen ::p/about-resource-instance)
@@ -43,7 +45,9 @@
 
 (defn set-document
   [lrs auth-identity params document merge?]
-  (p/-set-document lrs auth-identity params document merge?))
+  (try (p/-set-document lrs auth-identity params document merge?)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef set-document
   :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -68,7 +72,9 @@
 
 (defn get-document
   [lrs auth-identity params]
-  (p/-get-document lrs auth-identity params))
+  (try (p/-get-document lrs auth-identity params)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef get-document
   :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -89,7 +95,9 @@
 
 (defn get-document-ids
   [lrs auth-identity params]
-  (p/-get-document-ids lrs auth-identity params))
+  (try (p/-get-document-ids lrs auth-identity params)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef get-document-ids
   :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -110,7 +118,9 @@
 
 (defn delete-document
   [lrs auth-identity params]
-  (p/-delete-document lrs auth-identity params))
+  (try (p/-delete-document lrs auth-identity params)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef delete-document
  :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -130,7 +140,9 @@
 
 (defn delete-documents
   [lrs auth-identity params]
-  (p/-delete-documents lrs auth-identity params))
+  (try (p/-delete-documents lrs auth-identity params)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef delete-documents
  :args (s/cat :lrs           (with-lrs-gen ::p/document-resource-instance)
@@ -156,7 +168,9 @@
 (defn get-activity
   "Get the canonical representation of an activity"
   [lrs auth-identity params]
-  (p/-get-activity lrs auth-identity params))
+  (try (p/-get-activity lrs auth-identity params)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef get-activity
   :args (s/cat :lrs           (with-lrs-gen ::p/activity-info-resource-instance)
@@ -184,7 +198,9 @@
 (defn get-person
   "Get an object representing an actor"
   [lrs auth-identity params]
-  (p/-get-person lrs auth-identity params))
+  (try (p/-get-person lrs auth-identity params)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef get-person
   :args (s/cat :lrs           (with-lrs-gen ::p/agent-info-resource-instance)
@@ -214,7 +230,9 @@
 (defn store-statements
   "Store statements and attachments in the LRS"
   [lrs auth-identity statements attachments]
-  (p/-store-statements lrs auth-identity statements attachments))
+  (try (p/-store-statements lrs auth-identity statements attachments)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef store-statements
   :args (s/cat :lrs           (with-lrs-gen ::p/statements-resource-instance)
@@ -239,7 +257,9 @@
 (defn get-statements
   "Get statements from the LRS"
   [lrs auth-identity params ltags]
-  (p/-get-statements lrs auth-identity params ltags))
+  (try (p/-get-statements lrs auth-identity params ltags)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef get-statements
   :args (s/cat :lrs           (with-lrs-gen ::p/statements-resource-instance)
@@ -261,6 +281,7 @@
                :ltags         (s/coll-of ::xs/language-tag))
   :ret ::p/get-statements-async-ret)
 
+;; TODO: Figure out error strategy, maybe wrap return in map
 (defn consistent-through
   "Get a timestamp for use in the X-Experience-API-Consistent-Through header"
   [lrs ctx auth-identity]
@@ -291,7 +312,9 @@
 (defn authenticate
   "Given the LRS and context, return an identity or nil (401)"
   [lrs ctx]
-  (p/-authenticate lrs ctx))
+  (try (p/-authenticate lrs ctx)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef authenticate
   :args (s/cat :lrs (with-lrs-gen ::p/lrs-auth-instance)
@@ -302,7 +325,9 @@
   "Given the LRS and context, return true if the user is allowed to do a given
    thing."
   [lrs ctx auth-identity]
-  (p/-authorize lrs ctx auth-identity))
+  (try (p/-authorize lrs ctx auth-identity)
+       (catch Exception ex
+         {:error ex})))
 
 (s/fdef auth
   :args (s/cat :lrs           (with-lrs-gen ::p/lrs-auth-instance)

--- a/src/main/com/yetanalytics/lrs.cljc
+++ b/src/main/com/yetanalytics/lrs.cljc
@@ -21,7 +21,7 @@
   "Get information about this LRS"
   [lrs auth-identity]
   (try (p/-get-about lrs auth-identity)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef get-about
@@ -46,7 +46,7 @@
 (defn set-document
   [lrs auth-identity params document merge?]
   (try (p/-set-document lrs auth-identity params document merge?)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef set-document
@@ -73,7 +73,7 @@
 (defn get-document
   [lrs auth-identity params]
   (try (p/-get-document lrs auth-identity params)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef get-document
@@ -96,7 +96,7 @@
 (defn get-document-ids
   [lrs auth-identity params]
   (try (p/-get-document-ids lrs auth-identity params)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef get-document-ids
@@ -119,7 +119,7 @@
 (defn delete-document
   [lrs auth-identity params]
   (try (p/-delete-document lrs auth-identity params)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef delete-document
@@ -141,7 +141,7 @@
 (defn delete-documents
   [lrs auth-identity params]
   (try (p/-delete-documents lrs auth-identity params)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef delete-documents
@@ -169,7 +169,7 @@
   "Get the canonical representation of an activity"
   [lrs auth-identity params]
   (try (p/-get-activity lrs auth-identity params)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef get-activity
@@ -199,7 +199,7 @@
   "Get an object representing an actor"
   [lrs auth-identity params]
   (try (p/-get-person lrs auth-identity params)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef get-person
@@ -231,7 +231,7 @@
   "Store statements and attachments in the LRS"
   [lrs auth-identity statements attachments]
   (try (p/-store-statements lrs auth-identity statements attachments)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef store-statements
@@ -258,7 +258,7 @@
   "Get statements from the LRS"
   [lrs auth-identity params ltags]
   (try (p/-get-statements lrs auth-identity params ltags)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef get-statements
@@ -313,7 +313,7 @@
   "Given the LRS and context, return an identity or nil (401)"
   [lrs ctx]
   (try (p/-authenticate lrs ctx)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef authenticate
@@ -326,7 +326,7 @@
    thing."
   [lrs ctx auth-identity]
   (try (p/-authorize lrs ctx auth-identity)
-       (catch Exception ex
+       (catch #?(:clj Exception :cljs js/Error) ex
          {:error ex})))
 
 (s/fdef auth

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor.cljc
@@ -217,6 +217,8 @@
                              (get-in ctx [:request :request-method])))
                ctx))}))
 
+;; TODO: Remove this, is a downstream responsibility
+
 ;; Gracefully handle uncaught errors, deferring to custom responses.
 
 (defn- exi?
@@ -420,7 +422,6 @@
            :cljs (body-params/body-params))]
     [x-forwarded-for-interceptor
      http/json-body
-     error-interceptor
      body-params
      xapi/alternate-request-syntax-interceptor
      set-xapi-version-interceptor

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor.cljc
@@ -217,8 +217,6 @@
                              (get-in ctx [:request :request-method])))
                ctx))}))
 
-;; TODO: Remove this, is a downstream responsibility
-
 ;; Gracefully handle uncaught errors, deferring to custom responses.
 
 (defn- exi?
@@ -245,22 +243,24 @@
           ;; Log all unhandled/bubbled errors
           (log/error :msg "Unhandled LRS Error"
                      :exception ex)
-          (let [err-type
-                (cond
-                  (nil? ex)    {:name "unknown"}
-                  (exi? ex)    (let [{:keys [type exception-type]} (ex-data ex)
-                                     type-k (or exception-type
-                                                type
-                                                :unknown/unknown)
-                                     [tns tname] ((juxt namespace name) type-k)]
-                                 (merge (when tns {:ns tns})
-                                        {:name tname}))
-                  (error? ex)  {:name (str (type ex))}
-                  (string? ex) {:name ex}
-                  :else        {:name "unknown"})]
-            (assoc ctx :response {:status 500
-                                  :body   {:error
-                                           {:type err-type}}})))))}))
+          (assoc ctx
+                 :response
+                 {:status 500
+                  :body {:error
+                         (merge
+                          {:message "Unhandled LRS Error"}
+                          (cond
+                            (nil? ex)    {:type "unknown"}
+                            (exi? ex)    (let [{:keys [type exception-type]} (ex-data ex)
+                                               type-k (or exception-type
+                                                          type
+                                                          :unknown/unknown)
+                                               [tns tname] ((juxt namespace name) type-k)]
+                                           (merge (when tns {:ns tns})
+                                                  {:type tname}))
+                            (error? ex)  {:type (str (type ex))}
+                            (string? ex) {:type ex}
+                            :else        {:type "unknown"}))}}))))}))
 
 ;; Time Requests
 

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -261,7 +261,7 @@
        (try (assoc-in ctx
                       [:response :headers "X-Experience-API-Consistent-Through"]
                       (lrs/consistent-through lrs ctx auth-identity))
-            (catch Exception ex
+            (catch #?(:clj Exception :cljs js/Error) ex
               (assoc ctx
                      :io.pedestal.interceptor.chain/error
                      ex)))

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -258,9 +258,13 @@
                    [:response :headers "X-Experience-API-Consistent-Through"]
                    (a/<! (lrs/consistent-through-async lrs ctx auth-identity))))
        (lrsp/statements-resource? lrs)
-       (assoc-in ctx
-                 [:response :headers "X-Experience-API-Consistent-Through"]
-                 (lrs/consistent-through lrs ctx auth-identity))
+       (try (assoc-in ctx
+                      [:response :headers "X-Experience-API-Consistent-Through"]
+                      (lrs/consistent-through lrs ctx auth-identity))
+            (catch Exception ex
+              (assoc ctx
+                     :io.pedestal.interceptor.chain/error
+                     ex)))
        :else
        (assoc-in ctx
                  [:response :headers "X-Experience-API-Consistent-Through"]

--- a/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
@@ -91,12 +91,14 @@
 
   Optional keys:
     :path-prefix - defines the prefix from root for xAPI routes, default /xapi
-    :wrap-interceptors - a vector of interceptors to apply to every route"
+    :wrap-interceptors - a vector of interceptors to apply to every route.
+      The default vector includes an error interceptor which should be replaced
+      if this setting is provided."
   [{:keys [lrs
            path-prefix
            wrap-interceptors]
     :or {path-prefix "/xapi"
-         wrap-interceptors []}}]
+         wrap-interceptors [i/error-interceptor]}}]
   (let [lrs-i                       (i/lrs-interceptor lrs)
         global-interceptors-no-auth (into wrap-interceptors
                                           (conj i/common-interceptors

--- a/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
@@ -85,11 +85,18 @@
     :enter (fn health-fn [ctx]
              (assoc ctx :response {:status 200 :body ""}))}))
 
-(defn build [{:keys [lrs
-                     path-prefix
-                     wrap-interceptors]
-              :or {path-prefix "/xapi"
-                   wrap-interceptors []}}]
+(defn build
+  "Given a map with :lrs implementation, builds and returns xAPI routes
+  in pedestal table format.
+
+  Optional keys:
+    :path-prefix - defines the prefix from root for xAPI routes, default /xapi
+    :wrap-interceptors - a vector of interceptors to apply to every route"
+  [{:keys [lrs
+           path-prefix
+           wrap-interceptors]
+    :or {path-prefix "/xapi"
+         wrap-interceptors []}}]
   (let [lrs-i                       (i/lrs-interceptor lrs)
         global-interceptors-no-auth (into wrap-interceptors
                                           (conj i/common-interceptors

--- a/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
@@ -85,22 +85,31 @@
     :enter (fn health-fn [ctx]
              (assoc ctx :response {:status 200 :body ""}))}))
 
-(defn build [{:keys [lrs path-prefix]
-                     :or {path-prefix "/xapi"}}]
+(defn build [{:keys [lrs
+                     path-prefix
+                     wrap-interceptors]
+              :or {path-prefix "/xapi"
+                   wrap-interceptors []}}]
   (let [lrs-i                       (i/lrs-interceptor lrs)
-        global-interceptors-no-auth (conj i/common-interceptors
-                                          lrs-i)
-        global-interceptors         (conj i/common-interceptors
-                                          lrs-i
-                                          auth-i/lrs-authenticate
-                                          auth-i/lrs-authorize)
-        protected-interceptors      (into global-interceptors
-                                          i/xapi-protected-interceptors)
-        document-interceptors       (into (conj i/doc-interceptors-base
+        global-interceptors-no-auth (into wrap-interceptors
+                                          (conj i/common-interceptors
+                                                lrs-i))
+        global-interceptors         (into wrap-interceptors
+                                          (conj i/common-interceptors
                                                 lrs-i
                                                 auth-i/lrs-authenticate
-                                                auth-i/lrs-authorize)
-                                          i/xapi-protected-interceptors)]
+                                                auth-i/lrs-authorize))
+        protected-interceptors      (into wrap-interceptors
+                                          (concat
+                                           global-interceptors
+                                           i/xapi-protected-interceptors))
+        document-interceptors       (into wrap-interceptors
+                                          (concat
+                                           (conj i/doc-interceptors-base
+                                                 lrs-i
+                                                 auth-i/lrs-authenticate
+                                                 auth-i/lrs-authorize)
+                                           i/xapi-protected-interceptors))]
     (into #{;; health check
             ["/health"
              :get (conj global-interceptors-no-auth
@@ -116,13 +125,14 @@
 
             ;; xapi statements
             [(format "%s/statements" path-prefix)
-             :get (into [auth-i/www-authenticate]
-                        (concat
-                         protected-interceptors
-                         [statements-i/set-consistent-through
-                          (xapi-i/params-interceptor
-                           :xapi.statements.GET.request/params)
-                          statements/handle-get]))]
+             :get (into
+                   [auth-i/www-authenticate]
+                   (concat
+                    protected-interceptors
+                    [statements-i/set-consistent-through
+                     (xapi-i/params-interceptor
+                      :xapi.statements.GET.request/params)
+                     statements/handle-get]))]
             [(format "%s/statements" path-prefix)
              :head (conj protected-interceptors
                          statements-i/set-consistent-through

--- a/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
@@ -388,17 +388,12 @@
                                       doc
                                       true))))
           ;; Sync
-          (post-response
-           ctx
-           (try
-             (lrs/set-document
-              lrs
-              auth-identity
-              params
-              doc
-              true)
-             (catch Exception ex
-               {:error ex})))))))})
+          (post-response ctx (lrs/set-document
+                              lrs
+                              auth-identity
+                              params
+                              doc
+                              true))))))})
 
 
 

--- a/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
@@ -388,12 +388,17 @@
                                       doc
                                       true))))
           ;; Sync
-          (post-response ctx (lrs/set-document
-                              lrs
-                              auth-identity
-                              params
-                              doc
-                              true))))))})
+          (post-response
+           ctx
+           (try
+             (lrs/set-document
+              lrs
+              auth-identity
+              params
+              doc
+              true)
+             (catch Exception ex
+               {:error ex})))))))})
 
 
 

--- a/src/main/com/yetanalytics/lrs/protocol.cljc
+++ b/src/main/com/yetanalytics/lrs/protocol.cljc
@@ -22,6 +22,13 @@
   `(memoize (fn [x#]
               (satisfies? ~protocol x#))))
 
+(defmacro try-sync
+  "Try body and wrap anything thrown in a map with :error key"
+  [& body]
+  `(try ~@body
+        (catch #?(:clj Exception :cljs js/Error) ex#
+          {:error ex#})))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Error
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
# LET MY PEOPLE THROW (Kinda)

Exception handling should be delegated to implementations based on their needs regarding logging, security, etc.

We were applying an error handling interceptor erroneously to all the routes but doc, this has been changed (see below)

We also included errors in the return spec for sync `lrs` methods, but did not catch and ensure these were included for the lib handling to use. Catching and passing of errors has been standardized across all sync method wrappers in `lrs.cljc` with the exception of `consistent-through`, which is called by an interceptor and functions differently.

Any error that is not explicitly handled by the `lrs` layer (a narrow class of specific named errors) will now be properly placed in the pedestal context map. Implementations can apply any error handling they wish by providing an error interceptor in the `:wrap-interceptors` vector passed to `routes/build`.

UPDATE: The _default_ for the `:wrap-interceptors` vector is now `[i/error-interceptor]` per @kelvinqian00's request, meaning the default behavior will not change for implementations, though it will now also apply to doc routes which it did not before.

- [x] remove error interceptor from common interceptors
- [x] add `:wrap-interceptors` arg to routs build for passing your own global interceptors
- [x] make return less weird for implementations that want to use it
- [x] ensure handler fns are properly passing thrown impl errors and not covering what should be 500s