### PR TITLE
Address CVEs in lrs lib

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,11 +6,12 @@
   com.yetanalytics/xapi-schema {:git/url "https://github.com/yetanalytics/xapi-schema.git"
                                 :sha "13b4e1a0da7676f61edb2344c47d6b71e32e846d"
                                 :exclusions [org.clojure/clojurescript]}
-  cheshire/cheshire {:mvn/version "5.10.0"}
+  cheshire/cheshire {:mvn/version "5.10.1"}
   io.pedestal/pedestal.service {:mvn/version "0.5.9"}
+  ;; Use this version since there is a CVE in Pedestal's version
+  ring/ring-core {:mvn/version "1.9.4"}
   macchiato/core {:mvn/version "0.2.17"
-                  :exclusions [funcool/cuerdas]
-                  }
+                  :exclusions [funcool/cuerdas]}
   funcool/cuerdas {:mvn/version "2020.03.26-2"}
   com.cognitect/transit-cljs {:mvn/version "0.8.256"}
   org.clojure/data.priority-map {:mvn/version "1.0.0"}


### PR DESCRIPTION
Update cheshire and ring libraries to their latest versions in order to address CVE-2020-28491 and CVE-2021-29425, respectively.

(NOTE: There are still CVEs from ClojureScript, but they cannot be eliminated via updating and they don't affect Clojure downstream apps.)