### PR TITLE
LRS-59 update merge-or-replace to handle missing ctypes

### DIFF
--- a/src/main/com/yetanalytics/lrs/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/xapi/document.cljc
@@ -187,14 +187,18 @@
             document)
           :updated
           (updated-stamp-now)))
-  ([old-doc new-doc]
+  ([{old-ctype :content-type
+     :as old-doc}
+    {new-ctype :content-type
+     :as new-doc}]
    (if old-doc
      (assoc
-      (cond
-        ;; both docs have the JSON content type
-        (every? #(.startsWith ^String % "application/json")
-                (map :content-type [old-doc
-                                    new-doc]))
+      (if ;; both docs have the JSON content type
+          (and old-ctype
+               new-ctype
+               (every? #(.startsWith ^String % "application/json")
+                       [old-ctype
+                        new-ctype]))
         (let [old-json (*read-json-contents*
                         (:contents old-doc))
               new-json (*read-json-contents*
@@ -206,10 +210,6 @@
                      :content-length (count merged-bytes)
                      :contents merged-bytes))
             new-doc))
-        ;; at least one doc doesn't have the JSON content type
-        (not (every? #(.startsWith ^String % "application/json")
-                     (map :content-type [old-doc
-                                         new-doc])))
         (throw (ex-info "Attempt to merge documents of different content types"
                         {:type    ::invalid-merge
                          :old-doc old-doc


### PR DESCRIPTION
[LRS-59] When we [made adjustments to allow for missing content-type and length](https://github.com/yetanalytics/lrs/pull/69), I neglected to modify the content-type checking in `merge-or-replace` to account for missing ctypes (it runs `.length` assuming a string).

[LRS-59]: https://yet.atlassian.net/browse/LRS-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ