### PR TITLE
LRS-68 Handle Async Multipart Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ To use the dev profile, which contains all dev/repl/test stuff, use the `:dev` a
 * `test-conformance` - Run all conformance tests.
 * `test-all` - Run all lib and conformance tests.
 
+## Implementation Notes
+
+### Async `GET /statements` Error Handling
+
+LRS Applications implementing the `com.yetanalytics.lrs.protocol/-get-statements-async` method return a channel containing results. Since the body is streamed it is not possible to change the status of the request if an error is encountered. Applications can immediately terminate the stream (resulting in a malformed body) by passing `:com.yetanalytics.lrs.protocol/async-error` to the channel. This is preferable to returning a structurally valid response that is missing data.
+
 ## Bench Testing
 
 Facilities to bench test any LRS with [DATASIM](https://github.com/yetanalytics/datasim) are available. For instance, to bench the in-memory LRS:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use the dev profile, which contains all dev/repl/test stuff, use the `:dev` a
 
 ### Async `GET /statements` Error Handling
 
-LRS Applications implementing the `com.yetanalytics.lrs.protocol/-get-statements-async` method return a channel containing results. Since the body is streamed it is not possible to change the status of the request if an error is encountered. Applications can immediately terminate the stream (resulting in a malformed body) by passing `:com.yetanalytics.lrs.protocol/async-error` to the channel. This is preferable to returning a structurally valid response that is missing data.
+LRS Applications implementing the `com.yetanalytics.lrs.protocol/-get-statements-async` method return a channel containing results. Since the body is streamed it is not possible to change the status of the request if an error is encountered. Applications can immediately terminate the stream (resulting in a malformed body) by passing `:com.yetanalytics.lrs.protocol/async-error` to the channel. This is preferable to returning a structurally valid response that is missing data. See [this PR](https://github.com/yetanalytics/lrs/pull/78) for more information.
 
 ## Bench Testing
 

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -270,23 +270,6 @@
                  [:response :headers "X-Experience-API-Consistent-Through"]
                  (ss/now-stamp))))})
 
-#?(:clj
-   (defn lazy-statement-result [{:keys [statements more]}
-                                ^OutputStream os]
-     (with-open [w (io/writer os)]
-       ;; Write everything up to the beginning of the statements
-       (.write w "{\"statements\": [")
-       (doseq [x (interpose :comma statements)]
-         (if (= :comma x)
-           (.write w ",")
-           (json/with-writer [w {}]
-             (json/write x))))
-       (let [^String terminal (if more
-                                (fmt "], \"more\": \"%s\"}" more)
-                                "]}")]
-         (.write w
-                 terminal)))))
-
 (defn json-string [x]
   #?(:clj (json/generate-string x)
      :cljs (.stringify js/JSON (clj->js x))))

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -282,6 +282,8 @@
              s-count 0]
         (if-let [x (a/<! statement-result-chan)]
           (case x
+            ;; terminate on error producing invalid JSON
+            ::lrsp/async-error nil
             :statements
             (do (a/>! body-chan "{\"statements\":[")
                 (recur :statements s-count))

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -4,7 +4,7 @@
              [clojure.java.io :as io]
              [io.pedestal.log :as log]]
        :cljs [cljs.nodejs
-              [goog.string :as gstring]
+              [goog.string :refer [format]]
               goog.string.format
               [com.yetanalytics.lrs.util.log :as log]])
    [io.pedestal.interceptor.chain :as chain]
@@ -23,8 +23,6 @@
    [clojure.string :as cs])
   #?(:clj (:import [java.io InputStream OutputStream]
                    [com.fasterxml.jackson.core JsonParseException])))
-
-(def fmt #?(:clj format :cljs gstring/format))
 
 ;; The general flow for these is 1. parse 2. validate 3. place in context
 
@@ -289,8 +287,8 @@
                 (recur :statements s-count))
             :more
             (do (a/>! body-chan
-                      (fmt "],\"more\":\"%s\"}"
-                           (a/<! statement-result-chan)))
+                      (format "],\"more\":\"%s\"}"
+                              (a/<! statement-result-chan)))
                 (recur :more s-count))
             ;; else
             (do

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
   (:require
    [clojure.core.async :as a :include-macros true]
+   [com.yetanalytics.lrs.protocol :as lrsp]
    #?@(:clj [[cheshire.core :as json]]
        :cljs [[goog.string :refer [format]]
               [goog.string.format]])))
@@ -40,12 +41,13 @@
                            crlf))
       (loop [stage   :init
              s-count 0] ; s-count is used with multiple statements to enclose
-        (when-let [x (a/<! statement-result-chan)]
+        (if-let [x (a/<! statement-result-chan)]
           (case x
+            ;; terminate immediately on async error
+            ::lrsp/async-error nil
             ;; Headers
             :statement
-            (do (a/>! body-chan (json-string (a/<! statement-result-chan)))
-                (recur :statement s-count))
+            (recur :statement s-count)
             :statements
             (do (a/>! body-chan statement-result-pre)
                 (recur :statements s-count))
@@ -61,6 +63,9 @@
               (recur :attachments s-count))
             ;; Now we have a stage, dispatch on that
             (case stage
+              :statement
+              (do (a/>! body-chan (json-string x))
+                  (recur :statement s-count))
               :statements
               (do
                 ;; Maybe comma
@@ -87,12 +92,12 @@
                 ;; Attachment Content
                 (a/>! body-chan
                       content)
-                (recur :attachments s-count))))))
-      ;; End
-      (a/>! body-chan (str crlf
-                           "--"
-                           boundary
-                           "--"))
+                (recur :attachments s-count))))
+          ;; Successful completion end boundary
+          (a/>! body-chan (str crlf
+                               "--"
+                               boundary
+                               "--"))))
       ;; Close the body chan
       (a/close! body-chan))
     body-chan))

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response.cljc
@@ -1,7 +1,6 @@
 (ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
   (:require
    [clojure.core.async :as a :include-macros true]
-   [clojure.string :as cs]
    #?@(:clj [[cheshire.core :as json]]
        :cljs [[goog.string :refer [format]]
               [goog.string.format]])))
@@ -29,7 +28,6 @@
      :cljs (.stringify js/JSON (clj->js data))))
 
 (defn build-multipart-async
-  "Produce a channel body for a multipart response"
   [statement-result-chan]
   (let [body-chan (a/chan)]
     (a/go
@@ -98,54 +96,3 @@
       ;; Close the body chan
       (a/close! body-chan))
     body-chan))
-
-(defn build-multipart-sync
-  "Produce a string body for a multipart response."
-  [{:keys [statement-result
-           statement
-           attachments]}]
-  (str
-   "--" boundary
-   ;; Statement JSON header
-   crlf
-   "Content-Type:application/json"
-   crlf
-   crlf
-   ;; Statement JSON
-   (cond
-     ;; single
-     statement
-     (json-string statement)
-     ;; multiple
-     statement-result
-     (let [{:keys [statements
-                   more]} statement-result]
-       (str
-        statement-result-pre
-        (cs/join ","
-                 (map json-string statements))
-        (if (not-empty more)
-          (format "],\"more\":\"%s\"}"
-                  more)
-          statement-result-post))))
-   (when (not-empty attachments)
-     (apply str
-            (for [{:keys [content contentType sha2]} attachments]
-              (str
-               ;; Attachment Headers
-               crlf
-               "--" boundary
-               crlf
-               (format "Content-Type:%s" contentType)
-               crlf
-               "Content-Transfer-Encoding:binary"
-               crlf
-               (format "X-Experience-API-Hash:%s" sha2)
-               crlf
-               crlf
-               ;; Attachment body
-               #?(:clj (slurp content)
-                  :cljs content)))))
-   ;; Close multipart
-   crlf
-   "--" boundary "--"))

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response.cljc
@@ -2,14 +2,11 @@
   (:require
    [clojure.core.async :as a :include-macros true]
    #?@(:clj [[cheshire.core :as json]]
-       :cljs [[goog.string :as gstring]
+       :cljs [[goog.string :refer [format]]
               [goog.string.format]])))
 
 ;; TODO: Dynamic boundary?
 ;; TODO: make this async, work on a servlet output stream
-
-(def fmt #?(:clj format
-            :cljs gstring/format))
 
 (def crlf "\r\n")
 
@@ -17,7 +14,7 @@
   "105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0")
 
 (def content-type
-  (fmt "multipart/mixed; boundary=%s"
+  (format "multipart/mixed; boundary=%s"
           boundary))
 
 (def statement-result-pre
@@ -53,8 +50,8 @@
             (do (a/>! body-chan statement-result-pre)
                 (recur :statements s-count))
             :more
-            (do (a/>! body-chan (fmt "],\"more\":\"%s\"}"
-                                     (a/<! statement-result-chan)))
+            (do (a/>! body-chan (format "],\"more\":\"%s\"}"
+                                        (a/<! statement-result-chan)))
                 (recur :more s-count))
             :attachments
             (do
@@ -80,11 +77,11 @@
                            "--"
                            boundary
                            crlf
-                           (fmt "Content-Type:%s" contentType)
+                           (format "Content-Type:%s" contentType)
                            crlf
                            "Content-Transfer-Encoding:binary"
                            crlf
-                           (fmt "X-Experience-API-Hash:%s" sha2)
+                           (format "X-Experience-API-Hash:%s" sha2)
                            crlf
                            crlf))
                 ;; Attachment Content

--- a/src/main/com/yetanalytics/lrs/pedestal/routes/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/statements.cljc
@@ -149,7 +149,8 @@
            statement-result
            statement
            attachments
-           etag]}]
+           etag]
+    :as ret}]
   (if error
     ;; Error!
     (error-response ctx error)
@@ -162,19 +163,7 @@
               {:status  200
                :headers (cond-> {"Content-Type" att-resp/content-type}
                           etag (assoc "etag" etag))
-               ;; shim, the protocol will be expected to return this
-               :body    (att-resp/build-multipart-async
-                         (a/to-chan
-                          (if (some? statement)
-                            ;; Single statement
-                            (concat (list :statement statement)
-                                    (cons :attachments attachments))
-                            ;; Multiple statements
-                            (concat (cons :statements
-                                          (:statements statement-result))
-                                    (when-let [more (:more statement-result)]
-                                      (list :more more))
-                                    (cons :attachments attachments)))))}
+               :body    (att-resp/build-multipart-sync ret)}
               (if (si/accept-html? ctx)
                 (if statement-result
                   ;; Multiple statements

--- a/src/main/com/yetanalytics/lrs/protocol.cljc
+++ b/src/main/com/yetanalytics/lrs/protocol.cljc
@@ -405,13 +405,18 @@
   (sc/from-port
    (or-error (s/keys :req-un [:store-statements-ret/statement-ids]))))
 
+(s/def ::async-error
+  #{::async-error})
+
 (s/def ::get-statements-async-ret
   (sc/from-port-coll
    (s/alt
-    ;; can return one or more errors
+    ;; can return one error
     :exception
     (s/cat :header #{:error}
            :error :ret/error)
+    ;; can return headers followed by zero or more items
+    ;; if ::async-error keyword is passed, terminates stream
     :result
     (s/cat :result
            (s/alt
@@ -425,7 +430,8 @@
                                      :more-link :xapi.statements.GET.response.statement-result/more))))
            :attachments
            (s/? (s/cat :header #{:attachments}
-                       :attachments (s/* ::ss/attachment)))))))
+                       :attachments (s/* ::ss/attachment)))
+           :error (s/? ::async-error)))))
 
 (s/def ::consistent-through-async-ret
   (sc/from-port

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test
   (:require [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
              :refer [build-multipart-async
+                     build-multipart-sync
                      json-string]]
             [clojure.string :as cs]
             [clojure.test :refer [deftest testing is]]
@@ -58,7 +59,7 @@
 
 (def boundary "105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0")
 
-(deftest build-multipart-async-single-test
+(deftest build-multipart-single-test
   (sup/test-async
    (a/go
      (is
@@ -81,9 +82,12 @@
                           attachment]))
              (->> (a/into []))
              a/<!
-             ->string-body))))))
+             ->string-body)
+         (build-multipart-sync
+          {:statement statement-with-attachment
+           :attachments [attachment]}))))))
 
-(deftest build-multipart-async-multiple-test
+(deftest build-multipart-multiple-test
   (sup/test-async
    (a/go
      (is
@@ -107,9 +111,14 @@
                           attachment]))
              (->> (a/into []))
              a/<!
-             ->string-body))))))
+             ->string-body)
+         (build-multipart-sync
+          {:statement-result
+           {:statements [statement-with-attachment
+                         statement-with-attachment]}
+           :attachments [attachment]}))))))
 
-(deftest build-multipart-async-multiple-more-test
+(deftest build-multipart-multiple-more-test
   (let [more "https://lrs.example.com/xapi/statements"]
     (sup/test-async
      (a/go
@@ -137,4 +146,10 @@
                             attachment]))
                (->> (a/into []))
                a/<!
-               ->string-body)))))))
+               ->string-body)
+           (build-multipart-sync
+            {:statement-result
+             {:statements [statement-with-attachment
+                           statement-with-attachment]
+              :more more}
+             :attachments [attachment]})))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -1,7 +1,6 @@
 (ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test
   (:require [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
              :refer [build-multipart-async
-                     build-multipart-sync
                      json-string]]
             [clojure.string :as cs]
             [clojure.test :refer [deftest testing is]]
@@ -59,7 +58,7 @@
 
 (def boundary "105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0")
 
-(deftest build-multipart-single-test
+(deftest build-multipart-async-single-test
   (sup/test-async
    (a/go
      (is
@@ -82,12 +81,9 @@
                           attachment]))
              (->> (a/into []))
              a/<!
-             ->string-body)
-         (build-multipart-sync
-          {:statement statement-with-attachment
-           :attachments [attachment]}))))))
+             ->string-body))))))
 
-(deftest build-multipart-multiple-test
+(deftest build-multipart-async-multiple-test
   (sup/test-async
    (a/go
      (is
@@ -111,14 +107,9 @@
                           attachment]))
              (->> (a/into []))
              a/<!
-             ->string-body)
-         (build-multipart-sync
-          {:statement-result
-           {:statements [statement-with-attachment
-                         statement-with-attachment]}
-           :attachments [attachment]}))))))
+             ->string-body))))))
 
-(deftest build-multipart-multiple-more-test
+(deftest build-multipart-async-multiple-more-test
   (let [more "https://lrs.example.com/xapi/statements"]
     (sup/test-async
      (a/go
@@ -146,10 +137,4 @@
                             attachment]))
                (->> (a/into []))
                a/<!
-               ->string-body)
-           (build-multipart-sync
-            {:statement-result
-             {:statements [statement-with-attachment
-                           statement-with-attachment]
-              :more more}
-             :attachments [attachment]})))))))
+               ->string-body)))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -1,11 +1,22 @@
 (ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test
   (:require [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
              :refer [build-multipart-async]]
+            [clojure.string :as cs]
             [clojure.test :refer [deftest testing is]]
             [clojure.core.async :as a]
-            [com.yetanalytics.test-support :as sup]
-            #?@(:cljs [[goog.string :refer [format]]
-                       [goog.string.format]])))
+            [com.yetanalytics.test-support :as sup]))
+
+(defn- ->string-body
+  [response-v]
+  (reduce
+   #?(:clj (fn [s x]
+             (str s
+                  (cond
+                    (string? x) x
+                    (bytes? x) (slurp x))))
+      :cljs str)
+   ""
+   response-v))
 
 (def content
   #?(:clj (.getBytes "some text\n some more" "UTF-8")
@@ -14,9 +25,12 @@
 (def attachment-sha2
   "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53")
 
+(def attachment-ctype
+  "text/plain")
+
 (def attachment
   {:content     content,
-   :contentType "text/plain",
+   :contentType attachment-ctype,
    :length      20,
    :sha2        attachment-sha2})
 
@@ -41,18 +55,24 @@
 (def stmt-json
   "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":20,\"sha2\":\"7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}")
 
+(def boundary "105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0")
+
 (deftest build-multipart-async-single-test
   (sup/test-async
    (a/go
      (is
-      (= ["--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:application/json\r\n\r\n"
-          stmt-json
-          (format
-           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:%s\r\n\r\n"
-           attachment-sha2)
-          #?(:clj (vec content)
-             :cljs "some text\n some more"),
-          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
+      (= (cs/join
+          "\r\n"
+          [(str "--" boundary)
+           (str "Content-Type:application/json\r\n")
+           stmt-json
+           (str "--" boundary)
+           (str "Content-Type:" attachment-ctype)
+           (str "Content-Transfer-Encoding:binary")
+           (str "X-Experience-API-Hash:" attachment-sha2 "\r\n")
+           #?(:clj (slurp content)
+              :cljs content)
+           (str "--" boundary "--")])
          (-> (build-multipart-async
               (a/to-chan [:statement
                           statement-with-attachment
@@ -60,55 +80,60 @@
                           attachment]))
              (->> (a/into []))
              a/<!
-             ;; In clojure, vec the byte arrays for comparison
-             #?(:clj (->> (map (fn [x] (if (bytes? x) (vec x) x)))))))))))
+             ->string-body))))))
 
 (deftest build-multipart-async-multiple-test
   (sup/test-async
    (a/go
      (is
-      (= ["--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:application/json\r\n\r\n"
-          "{\"statements\":["
-          stmt-json
-          "]}"
-          (format
-           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:%s\r\n\r\n"
-           attachment-sha2)
-          #?(:clj (vec content)
-             :cljs "some text\n some more")
-          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
+      (= (cs/join
+          "\r\n"
+          [(str "--" boundary)
+           (str "Content-Type:application/json\r\n")
+           (str "{\"statements\":[" stmt-json "," stmt-json "]}")
+           (str "--" boundary)
+           (str "Content-Type:" attachment-ctype)
+           (str "Content-Transfer-Encoding:binary")
+           (str "X-Experience-API-Hash:" attachment-sha2 "\r\n")
+           #?(:clj (slurp content)
+              :cljs content)
+           (str "--" boundary "--")])
          (-> (build-multipart-async
               (a/to-chan [:statements
+                          statement-with-attachment
                           statement-with-attachment
                           :attachments
                           attachment]))
              (->> (a/into []))
              a/<!
-             ;; In clojure, vec the byte arrays for comparison
-             #?(:clj (->> (map (fn [x] (if (bytes? x) (vec x) x)))))))))))
+             ->string-body))))))
 
 (deftest build-multipart-async-multiple-more-test
-  (sup/test-async
-   (a/go
-     (is
-      (= ["--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:application/json\r\n\r\n"
-          "{\"statements\":["
-          stmt-json
-          "],\"more\":\"https://lrs.example.com/xapi/statements\"}"
-          (format
-           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:%s\r\n\r\n"
-           attachment-sha2)
-          #?(:clj (vec content)
-             :cljs "some text\n some more")
-          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
-         (-> (build-multipart-async
-              (a/to-chan [:statements
-                          statement-with-attachment
-                          :more
-                          "https://lrs.example.com/xapi/statements"
-                          :attachments
-                          attachment]))
-             (->> (a/into []))
-             a/<!
-             ;; In clojure, vec the byte arrays for comparison
-             #?(:clj (->> (map (fn [x] (if (bytes? x) (vec x) x)))))))))))
+  (let [more "https://lrs.example.com/xapi/statements"]
+    (sup/test-async
+     (a/go
+       (is
+        (=
+         (cs/join
+          "\r\n"
+          [(str "--" boundary)
+           (str "Content-Type:application/json\r\n")
+           (str "{\"statements\":[" stmt-json "," stmt-json "],\"more\":\"" more "\"}")
+           (str "--" boundary)
+           (str "Content-Type:" attachment-ctype)
+           (str "Content-Transfer-Encoding:binary")
+           (str "X-Experience-API-Hash:" attachment-sha2 "\r\n")
+           #?(:clj (slurp content)
+              :cljs content)
+           (str "--" boundary "--")])
+           (-> (build-multipart-async
+                (a/to-chan [:statements
+                            statement-with-attachment
+                            statement-with-attachment
+                            :more
+                            more
+                            :attachments
+                            attachment]))
+               (->> (a/into []))
+               a/<!
+               ->string-body)))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -1,0 +1,98 @@
+(ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test
+  (:require [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
+             :refer [build-multipart-async]]
+            [clojure.test :refer [deftest testing is]]
+            [clojure.core.async :as a]
+            [com.yetanalytics.test-support :as sup]))
+
+(def statement-with-attachment
+  {"id"          "78efaab3-1c65-4cb7-9289-f34e0594b274"
+   "actor"       {"mbox"       "mailto:bob@example.com"
+                  "objectType" "Agent"}
+   "verb"        {"id" "https://example.com/verb"}
+   "object"      {"id" "https://example.com/activity"}
+   "timestamp"   "2022-05-04T13:32:10.486195Z"
+   "authority"   {"account"    {"homePage" "https://example.com"
+                                "name"     "someaccount"}
+                  "objectType" "Agent"}
+   "stored"      "2022-05-04T13:32:10.486195Z"
+   "version"     "1.0.3"
+   "attachments" [{"usageType"   "https://example.com/usagetype"
+                   "display"     {"en-US" "someattachment"}
+                   "contentType" "application/octet-stream"
+                   "length"      10
+                   "sha2"        "01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca"}]})
+
+(def content
+  #?(:clj (.getBytes "some text\n some more" "UTF-8")
+     :cljs "some text\n some more"))
+
+(def attachment
+  {:content     content,
+   :contentType "text/plain",
+   :length      20,
+   :sha2        "01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca"})
+
+(deftest build-multipart-async-single-test
+  (sup/test-async
+   (a/go
+     (is
+      (= ["--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:application/json\r\n\r\n"
+   "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":10,\"sha2\":\"01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}"
+   "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\r\n\r\n"
+   #?(:clj (vec content)
+      :cljs "some text\n some more"),
+   "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
+         (-> (build-multipart-async
+              (a/to-chan [:statement
+                          statement-with-attachment
+                          :attachments
+                          attachment]))
+             (->> (a/into []))
+             a/<!
+             ;; In clojure, vec the byte arrays for comparison
+             #?(:clj (->> (map (fn [x] (if (bytes? x) (vec x) x)))))))))))
+
+(deftest build-multipart-async-multiple-test
+  (sup/test-async
+   (a/go
+     (is
+      (= ["--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:application/json\r\n\r\n"
+          "{\"statements\":["
+          "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":10,\"sha2\":\"01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}"
+          "]}"
+          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\r\n\r\n"
+          (vec content)
+          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
+         (-> (build-multipart-async
+              (a/to-chan [:statements
+                          statement-with-attachment
+                          :attachments
+                          attachment]))
+             (->> (a/into []))
+             a/<!
+             ;; In clojure, vec the byte arrays for comparison
+             #?(:clj (->> (map (fn [x] (if (bytes? x) (vec x) x)))))))))))
+
+(deftest build-multipart-async-multiple-more-test
+  (sup/test-async
+   (a/go
+     (is
+      (= ["--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:application/json\r\n\r\n"
+          "{\"statements\":["
+          "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":10,\"sha2\":\"01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}"
+          "],\"more\":\"https://lrs.example.com/xapi/statements\"}"
+          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\r\n\r\n"
+          (vec content)
+          "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
+         (-> (build-multipart-async
+              (a/to-chan [:statements
+                          statement-with-attachment
+                          :more
+                          "https://lrs.example.com/xapi/statements"
+                          :attachments
+                          attachment]))
+             (->> (a/into []))
+             a/<!
+             ;; In clojure, vec the byte arrays for comparison
+             #?(:clj (->> (map (fn [x] (if (bytes? x) (vec x) x)))))))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test
   (:require [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response
-             :refer [build-multipart-async]]
+             :refer [build-multipart-async
+                     json-string]]
             [clojure.string :as cs]
             [clojure.test :refer [deftest testing is]]
             [clojure.core.async :as a]
@@ -53,7 +54,7 @@
                    "sha2"        attachment-sha2}]})
 
 (def stmt-json
-  "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":20,\"sha2\":\"7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}")
+  (json-string statement-with-attachment))
 
 (def boundary "105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0")
 

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -62,7 +62,8 @@
           "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":10,\"sha2\":\"01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}"
           "]}"
           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\r\n\r\n"
-          (vec content)
+          #?(:clj (vec content)
+             :cljs "some text\n some more")
           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
          (-> (build-multipart-async
               (a/to-chan [:statements
@@ -83,7 +84,8 @@
           "{\"object\":{\"id\":\"https://example.com/activity\"},\"authority\":{\"account\":{\"homePage\":\"https://example.com\",\"name\":\"someaccount\"},\"objectType\":\"Agent\"},\"verb\":{\"id\":\"https://example.com/verb\"},\"id\":\"78efaab3-1c65-4cb7-9289-f34e0594b274\",\"timestamp\":\"2022-05-04T13:32:10.486195Z\",\"version\":\"1.0.3\",\"stored\":\"2022-05-04T13:32:10.486195Z\",\"attachments\":[{\"usageType\":\"https://example.com/usagetype\",\"display\":{\"en-US\":\"someattachment\"},\"contentType\":\"application/octet-stream\",\"length\":10,\"sha2\":\"01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\"}],\"actor\":{\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}}"
           "],\"more\":\"https://lrs.example.com/xapi/statements\"}"
           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0\r\nContent-Type:text/plain\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca\r\n\r\n"
-          (vec content)
+          #?(:clj (vec content)
+             :cljs "some text\n some more")
           "\r\n--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--"]
          (-> (build-multipart-async
               (a/to-chan [:statements

--- a/src/test/com/yetanalytics/test_runner.cljc
+++ b/src/test/com/yetanalytics/test_runner.cljc
@@ -13,7 +13,8 @@
    com.yetanalytics.lrs.xapi.statements.timestamp-test
    com.yetanalytics.lrs.impl.memory-test
    com.yetanalytics.lrs.pedestal.http.multipart-mixed-test
-   com.yetanalytics.lrs.auth-test))
+   com.yetanalytics.lrs.auth-test
+   com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test))
 
 (defmethod test/report #?(:cljs [::test/default :begin-test-ns]
                           :clj :begin-test-ns)
@@ -49,7 +50,8 @@
    'com.yetanalytics.lrs.xapi.statements.timestamp-test
    'com.yetanalytics.lrs.impl.memory-test
    'com.yetanalytics.lrs.pedestal.http.multipart-mixed-test
-   'com.yetanalytics.lrs.auth-test))
+   'com.yetanalytics.lrs.auth-test
+   'com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test))
 
 (defn ^:export -main []
   #?(:clj

--- a/src/test/com/yetanalytics/test_support.cljc
+++ b/src/test/com/yetanalytics/test_support.cljc
@@ -1,9 +1,10 @@
 (ns com.yetanalytics.test-support
   (:require
+   [clojure.core.async :as a :include-macros true]
    [clojure.spec.alpha :as s :include-macros true]
+   [clojure.test :refer [deftest testing is #?(:cljs async)] :include-macros true]
    [clojure.test.check]
-   #?@(:clj [[clojure.test :refer [deftest testing is] :include-macros true]
-             [clojure.spec.test.alpha :as stest :include-macros true]])))
+   #?@(:clj [[clojure.spec.test.alpha :as stest :include-macros true]])))
 
 #?(:clj (alias 'stc 'clojure.spec.test.check))
 
@@ -50,3 +51,13 @@
                  (is
                   ~(list 'empty?
                          `(failures (stest/check (quote ~sym) ~opts))))))))))
+
+;; a la https://stackoverflow.com/a/30781278/3532563
+(defn test-async
+  "Asynchronous test awaiting ch to produce a value or close."
+  [ch]
+  #?(:clj
+     (a/<!! ch)
+     :cljs
+     (async done
+            (a/take! ch (fn [_] (done))))))


### PR DESCRIPTION
[LRS-68] ~~Currently the async multipart body build fn simply omits nil attachments. It should instead make the multipart result invalid, since the status cannot be changed. It is also currently utilized for sync responses, which is extra overhead.~~

~~Separating the sync and async approaches to building multipart responses (and testing them for parity) will let us have different behaviors WRT errors in mid-multipart on async.~~

After more research, the universal (sync + async) use of a channel body is probably more desirable as it allows even sync implementations to return things like `File` for attachment content which are passed for direct handling by pedestal.

This leaves the problem with the current impl that it simply omits attachments when errors occur, rather than terminating the response (and thus returning an invalid multipart), which is the only indication a client will get that the response is invalid.

This PR modifies the two async body formation functions (json and multipart) to accept a `::lrsp/async-error` keyword in lieu of a statement, attachment or header. Upon receiving it they will immediately close the stream.

In practice this has no effect on sync impls like `lrsql` where an eager result is provided.

See the multipart body tests for examples of early termination: https://github.com/yetanalytics/lrs/blob/bd55295491e33523dd0c83c5c86cedf6389c3025/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc

[LRS-68]: https://yet.atlassian.net/browse/LRS-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ