### PR TITLE
LRS-70 Pass multipart statement to attachment validation to impl

### DIFF
--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -74,5 +74,6 @@
                  (try (validate-statements-multiparts
                        statements
                        [multipart])
-                      (catch clojure.lang.ExceptionInfo exi
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs ExceptionInfo) exi
                         (-> exi ex-data :type))))))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -1,0 +1,78 @@
+(ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment-test
+  (:require [clojure.test :refer [deftest testing is] :include-macros true]
+            [clojure.spec.test.alpha :as stest :include-macros true]
+            [com.yetanalytics.test-support :refer [failures stc-opts]]
+            [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment
+             :as attachment
+             :refer [validate-statements-multiparts]])
+  #?(:clj (:import [java.io ByteArrayInputStream])))
+
+(deftest validate-statements-multiparts-test
+  (let [s-template {"id"          "78efaab3-1c65-4cb7-9289-f34e0594b274"
+                    "actor"       {"mbox"       "mailto:bob@example.com"
+                                   "objectType" "Agent"}
+                    "verb"        {"id" "https://example.com/verb"}
+                    "timestamp"   "2022-05-04T13:32:10.486195Z"
+                    "version"     "1.0.3"
+                    "object"      {"id" "https://example.com/activity"}}
+        multipart {:content-type "application/octet-stream"
+                   :content-length 20
+                   :headers {"Content-Type"              "application/octet-stream"
+                             "Content-Transfer-Encoding" "binary"
+                             "X-Experience-API-Hash"     "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}
+                   :input-stream #?(:clj (ByteArrayInputStream.
+                                          (.getBytes "some text\n some more" "UTF-8"))
+                                    :cljs "some text\n some more")}]
+    (testing "empty"
+      (is (= [[] []]
+             (validate-statements-multiparts
+              []
+              []))))
+
+    (testing "simple"
+      (let [statements
+            [(assoc s-template
+                    "attachments"
+                    [{"usageType"   "https://example.com/usagetype"
+                      "display"     {"en-US" "someattachment"}
+                      "contentType" "application/octet-stream"
+                      "length"      20
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]
+            multiparts
+            [multipart]]
+        (is (= [statements multiparts]
+               (validate-statements-multiparts
+                statements
+                multiparts)))))
+    (testing "dup reference"
+      ;; TODO: per this test, the lib currently requires that each referenced
+      ;; multipart be provided, even if they share a SHA.
+      ;; Is this what we intend?
+      (let [statements
+            [(assoc s-template
+                    "attachments"
+                    [{"usageType"   "https://example.com/usagetype"
+                      "display"     {"en-US" "someattachment"}
+                      "contentType" "application/octet-stream"
+                      "length"      20
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}
+                     {"usageType"   "https://example.com/usagetype"
+                      "display"     {"en-US" "someattachment"}
+                      "contentType" "application/octet-stream"
+                      "length"      20
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]
+            multiparts
+            [multipart
+             multipart]]
+        (testing "works with a dup multipart"
+          (is (= [statements multiparts]
+                 (validate-statements-multiparts
+                  statements
+                  multiparts))))
+        (testing "fails with a single multipart"
+          (is (= ::attachment/invalid-multipart-format
+                 (try (validate-statements-multiparts
+                       statements
+                       [multipart])
+                      (catch clojure.lang.ExceptionInfo exi
+                        (-> exi ex-data :type))))))))))

--- a/src/test/com/yetanalytics/lrs_test.clj
+++ b/src/test/com/yetanalytics/lrs_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [com.yetanalytics.test-support :as support :refer [deftest-check-ns]]
             [com.yetanalytics.lrs.impl.memory :as mem]
-            [com.yetanalytics.lrs :refer [get-statements store-statements]]
+            [com.yetanalytics.lrs :as lrs]
             [clojure.string :as cs]
             [com.yetanalytics.datasim.input :as sim-input]
             [com.yetanalytics.datasim.sim :as sim]
@@ -27,32 +27,32 @@
               :input :json "dev-resources/datasim/input/tc3.json"))))
 
 ;; instrument LRS api fns throughout tests
-(stest/instrument `[get-about
-                    get-about-async
-                    set-document
-                    set-document-async
-                    get-document
-                    get-document-async
-                    get-document-ids
-                    get-document-ids-async
-                    delete-document
-                    delete-document-async
-                    delete-documents
-                    delete-documents-async
-                    get-activity
-                    get-activity-async
-                    get-person
-                    get-person-async
-                    store-statements
-                    store-statements-async
-                    get-statements
-                    get-statements-async
-                    consistent-through
-                    consistent-through-async
-                    authenticate
-                    authenticate-async
-                    authorize
-                    authorize-async])
+(stest/instrument `[lrs/get-about
+                    lrs/get-about-async
+                    lrs/set-document
+                    lrs/set-document-async
+                    lrs/get-document
+                    lrs/get-document-async
+                    lrs/get-document-ids
+                    lrs/get-document-ids-async
+                    lrs/delete-document
+                    lrs/delete-document-async
+                    lrs/delete-documents
+                    lrs/delete-documents-async
+                    lrs/get-activity
+                    lrs/get-activity-async
+                    lrs/get-person
+                    lrs/get-person-async
+                    lrs/store-statements
+                    lrs/store-statements-async
+                    lrs/get-statements
+                    lrs/get-statements-async
+                    lrs/consistent-through
+                    lrs/consistent-through-async
+                    lrs/authenticate
+                    lrs/authenticate-async
+                    lrs/authorize
+                    lrs/authorize-async])
 
 (deftest query-test
   (let [auth-id {:auth   {:no-op {}}
@@ -66,12 +66,12 @@
         ;; no normalization going on
         s-count        100
         lrs            (doto (mem/new-lrs {:statements-result-max s-count})
-                         (store-statements auth-id
-                                           (into [] (take s-count)
-                                                 test-statements)
-                                           []))
+                         (lrs/store-statements auth-id
+                                               (into [] (take s-count)
+                                                     test-statements)
+                                               []))
         get-ss         #(into []
-                              (get-in (get-statements lrs auth-id % #{"en-US"})
+                              (get-in (lrs/get-statements lrs auth-id % #{"en-US"})
                                       [:statement-result :statements]))
         ret-statements (get-ss {:limit 100})]
     (testing (format "%s valid return statements?" (count ret-statements))
@@ -166,10 +166,10 @@
                    (get "id"))]
         (is
          (:statement
-          (get-statements lrs
-                          auth-id
-                          {:statementId (cs/upper-case id)}
-                          #{"en-US"})))))
+          (lrs/get-statements lrs
+                              auth-id
+                              {:statementId (cs/upper-case id)}
+                              #{"en-US"})))))
 
     (testing "registration param is normalized"
       (let [reg (-> ret-statements
@@ -178,30 +178,30 @@
         (is reg)
         (is
          (not-empty
-          (get-in  (get-statements lrs
-                                   auth-id
-                                   {:registration (cs/upper-case reg)}
-                                   #{"en-US"})
+          (get-in  (lrs/get-statements lrs
+                                       auth-id
+                                       {:registration (cs/upper-case reg)}
+                                       #{"en-US"})
                    [:statement-result :statements])))))
 
     (testing "ID keys are normalized"
       (let [s   (first test-statements)
             id  (get s "id")
             lrs (doto (mem/new-lrs {:statements-result-max s-count})
-                  (store-statements
+                  (lrs/store-statements
                    auth-id
                    [(-> s
                         (update "id" cs/upper-case)
                         (update-in ["context" "registration"] cs/upper-case))]
                    []))]
-        (is (:statement (get-statements
+        (is (:statement (lrs/get-statements
                          lrs
                          auth-id
                          {:statementId id}
                          #{"en-US"})))
-          ;; This test will pass even w/o normalized IDs, but it makes sure we
-          ;; don't screw up the rel index
-        (is (not-empty (get-in (get-statements
+        ;; This test will pass even w/o normalized IDs, but it makes sure we
+        ;; don't screw up the rel index
+        (is (not-empty (get-in (lrs/get-statements
                                 lrs
                                 auth-id
                                 {:verb (get-in s ["verb" "id"])}
@@ -209,7 +209,7 @@
                                [:statement-result :statements])))
 
         (testing "reg index"
-          (is (not-empty (get-in (get-statements
+          (is (not-empty (get-in (lrs/get-statements
                                   lrs
                                   auth-id
                                   {:registration (get-in s ["context"
@@ -219,8 +219,8 @@
 
         (testing "original case is preserved"
           (is (= (cs/upper-case id)
-                 (get-in (get-statements lrs
-                                         auth-id
-                                         {:statementId id}
-                                         #{"en-US"})
+                 (get-in (lrs/get-statements lrs
+                                             auth-id
+                                             {:statementId id}
+                                             #{"en-US"})
                          [:statement "id"]))))))))

--- a/src/test/com/yetanalytics/test_runner.cljc
+++ b/src/test/com/yetanalytics/test_runner.cljc
@@ -14,6 +14,7 @@
    com.yetanalytics.lrs.impl.memory-test
    com.yetanalytics.lrs.pedestal.http.multipart-mixed-test
    com.yetanalytics.lrs.auth-test
+   com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment-test
    com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test))
 
 (defmethod test/report #?(:cljs [::test/default :begin-test-ns]
@@ -51,6 +52,7 @@
    'com.yetanalytics.lrs.impl.memory-test
    'com.yetanalytics.lrs.pedestal.http.multipart-mixed-test
    'com.yetanalytics.lrs.auth-test
+   'com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment-test
    'com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test))
 
 (defn ^:export -main []


### PR DESCRIPTION
[LRS-70] We match and validate statement data to attachments, but throw out the resulting pairing.

It would be useful for impls to have this for a variety of reasons, chiefly addressing attachment storage

Also examine current behavior: We require that there be a (possibly duplicate) attachment present for each reference, even if the SHA2 is the same. Figure out if this is intended + correct behavior.

[LRS-70]: https://yet.atlassian.net/browse/LRS-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ