### PR TITLE
LRS-66 Update core.async and replace deprecated functions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
   org.clojure/clojurescript {:mvn/version "1.10.741"}
-  org.clojure/core.async {:mvn/version "1.1.587"}
+  org.clojure/core.async {:mvn/version "1.5.648"}
   com.yetanalytics/xapi-schema {:mvn/version "1.2.0"
                                 :exclusions [org.clojure/clojurescript]}
   cheshire/cheshire {:mvn/version "5.10.1"}

--- a/src/bench/com/yetanalytics/lrs/bench.clj
+++ b/src/bench/com/yetanalytics/lrs/bench.clj
@@ -259,7 +259,7 @@
                                   :form-params batch}))
                         (partition-all batch-size payload))
         ;; enter the async zone
-        req-chan  (a/to-chan requests)
+        req-chan  (a/to-chan! requests)
         resp-chan (a/chan (count requests)) ; buffer enough for all results
         ;; init time
         ^Instant t-zero (Instant/now)

--- a/src/main/com/yetanalytics/lrs/pedestal/routes/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/statements.cljc
@@ -164,7 +164,7 @@
                           etag (assoc "etag" etag))
                ;; shim, the protocol will be expected to return this
                :body    (att-resp/build-multipart-async
-                         (a/to-chan
+                         (a/to-chan!
                           (if (some? statement)
                             ;; Single statement
                             (concat (list :statement statement)
@@ -190,7 +190,7 @@
                   {:status  200
                    :headers {"Content-Type" "application/json"}
                    :body    (si/lazy-statement-result-async
-                             (a/to-chan
+                             (a/to-chan!
                               (concat (cons :statements
                                             (:statements statement-result))
                                       (when-let [more (:more statement-result)]

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment/response_test.cljc
@@ -76,10 +76,10 @@
               :cljs content)
            (str "--" boundary "--")])
          (-> (build-multipart-async
-              (a/to-chan [:statement
-                          statement-with-attachment
-                          :attachments
-                          attachment]))
+              (a/to-chan! [:statement
+                           statement-with-attachment
+                           :attachments
+                           attachment]))
              (->> (a/into []))
              a/<!
              ->string-body))))))
@@ -93,8 +93,8 @@
           [(str "--" boundary)
            (str "Content-Type:application/json\r\n\r\n")])
          (-> (build-multipart-async
-              (a/to-chan [:statement
-                          ::lrsp/async-error]))
+              (a/to-chan! [:statement
+                           ::lrsp/async-error]))
              (->> (a/into []))
              a/<!
              ->string-body))))))
@@ -111,10 +111,10 @@
            ;; No attachments or closing boundary
            ])
          (-> (build-multipart-async
-              (a/to-chan [:statement
-                          statement-with-attachment
-                          :attachments
-                          ::lrsp/async-error]))
+              (a/to-chan! [:statement
+                           statement-with-attachment
+                           :attachments
+                           ::lrsp/async-error]))
              (->> (a/into []))
              a/<!
              ->string-body))))))
@@ -136,11 +136,11 @@
               :cljs content)
            (str "--" boundary "--")])
          (-> (build-multipart-async
-              (a/to-chan [:statements
-                          statement-with-attachment
-                          statement-with-attachment
-                          :attachments
-                          attachment]))
+              (a/to-chan! [:statements
+                           statement-with-attachment
+                           statement-with-attachment
+                           :attachments
+                           attachment]))
              (->> (a/into []))
              a/<!
              ->string-body))))))
@@ -157,9 +157,9 @@
            ;; No closing JSON, boundary
            ])
          (-> (build-multipart-async
-              (a/to-chan [:statements
-                          statement-with-attachment
-                          ::lrsp/async-error]))
+              (a/to-chan! [:statements
+                           statement-with-attachment
+                           ::lrsp/async-error]))
              (->> (a/into []))
              a/<!
              ->string-body))))))
@@ -182,12 +182,12 @@
            ;; No closing boundary
            ])
          (-> (build-multipart-async
-              (a/to-chan [:statements
-                          statement-with-attachment
-                          statement-with-attachment
-                          :attachments
-                          attachment
-                          ::lrsp/async-error]))
+              (a/to-chan! [:statements
+                           statement-with-attachment
+                           statement-with-attachment
+                           :attachments
+                           attachment
+                           ::lrsp/async-error]))
              (->> (a/into []))
              a/<!
              ->string-body))))))
@@ -210,14 +210,14 @@
            #?(:clj (slurp content)
               :cljs content)
            (str "--" boundary "--")])
-           (-> (build-multipart-async
-                (a/to-chan [:statements
-                            statement-with-attachment
-                            statement-with-attachment
-                            :more
-                            more
-                            :attachments
-                            attachment]))
-               (->> (a/into []))
-               a/<!
-               ->string-body)))))))
+         (-> (build-multipart-async
+              (a/to-chan! [:statements
+                           statement-with-attachment
+                           statement-with-attachment
+                           :more
+                           more
+                           :attachments
+                           attachment]))
+             (->> (a/into []))
+             a/<!
+             ->string-body)))))))


### PR DESCRIPTION
We're getting a lot of deprecation warnings downstream for `to-chan`, it should be replaced with the explicitly non-blocking version `to-chan!`