### PR TITLE
LRS-72 Handle deduplicated attachment multiparts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ To use the dev profile, which contains all dev/repl/test stuff, use the `:dev` a
 
 LRS Applications implementing the `com.yetanalytics.lrs.protocol/-get-statements-async` method return a channel containing results. Since the body is streamed it is not possible to change the status of the request if an error is encountered. Applications can immediately terminate the stream (resulting in a malformed body) by passing `:com.yetanalytics.lrs.protocol/async-error` to the channel. This is preferable to returning a structurally valid response that is missing data. See [this PR](https://github.com/yetanalytics/lrs/pull/78) for more information.
 
+### Statement Attachment Handling & Normalization
+
+#### `PUT/POST /statements`
+
+xAPI clients can send statement data with arbitrary file attachments using the `multipart/mixed` Content-Type [per the spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#requirements-for-attachment-statement-batches). An attachment referenced in an xAPI statement (or substatement) that does not have a `fileUrl` property must be included *at least once* in the request body as a part identified by hash. In practice this means that duplicate attachments may be present on the request. `lrs` will normalize/deduplicate attachments before sending them to implementation code such that every attachment in the list has a distinct hash. See [this PR](https://github.com/yetanalytics/lrs/pull/81) for more information.
+
+Note that requests containing attachments *not* referenced in statement data will fail with a 400 status.
+
+#### `GET /statements`
+
+LRS implementations should return attachments in the same normalized form mentioned above, though this is not checked or enforced by `lrs`.
+
 ## Bench Testing
 
 Facilities to bench test any LRS with [DATASIM](https://github.com/yetanalytics/datasim) are available. For instance, to bench the in-memory LRS:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ LRS Applications implementing the `com.yetanalytics.lrs.protocol/-get-statements
 
 #### `PUT/POST /statements`
 
-xAPI clients can send statement data with arbitrary file attachments using the `multipart/mixed` Content-Type [per the spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#requirements-for-attachment-statement-batches). An attachment referenced in an xAPI statement (or substatement) that does not have a `fileUrl` property must be included *at least once* in the request body as a part identified by hash. In practice this means that duplicate attachments may be present on the request. `lrs` will normalize/deduplicate attachments before sending them to implementation code such that every attachment in the list has a distinct hash. See [this PR](https://github.com/yetanalytics/lrs/pull/81) for more information.
+xAPI clients can send statement data with arbitrary file attachments using the `multipart/mixed` Content-Type [per the spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#requirements-for-attachment-statement-batches). An attachment referenced in an xAPI statement (or substatement) that does not have a `fileUrl` property must be included *at least once* in the request body as a part identified by hash. In addition, multiple attachment objects, either in a single statement or across multiple statements in the same request, can refer to the same attachment, as recommended by the spec.
+
+In practice this means that duplicate attachments *may* be present on the request. `lrs` will normalize/deduplicate attachments before sending them to implementation code such that every attachment in the list has a distinct hash. See [this PR](https://github.com/yetanalytics/lrs/pull/81) for more information.
 
 Note that requests containing attachments *not* referenced in statement data will fail with a 400 status.
 

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -186,8 +186,8 @@
        (if-let [statement-data (get-in ctx [:request :json-params])]
          (try (condp s/valid? statement-data
                 ::xs/statement
-                (let [[_ valid-multiparts]
-                      (attachment/validate-statements-multiparts
+                (let [valid-multiparts
+                      (attachment/validate-multiparts
                        [statement-data]
                        multiparts)
                       attachment-data
@@ -199,8 +199,8 @@
                           ::xs/statement statement-data
                           :xapi.statements/attachments attachment-data))
                 ::xs/statements
-                (let [[_ valid-multiparts]
-                      (attachment/validate-statements-multiparts
+                (let [valid-multiparts
+                      (attachment/validate-multiparts
                        statement-data
                        multiparts)
                       attachment-data

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment.cljc
@@ -211,9 +211,8 @@
              (if fileUrl
                state
                (throw
-                ;; TODO: name of this error?
-                (ex-info "Invalid multipart format"
-                         {:type ::invalid-multipart-format})))))
+                (ex-info "Statement references missing attachment and no fileUrl is present"
+                         {:type ::statement-attachment-missing})))))
          {:sha2s []
           :mpart-map (multipart-map-dedupe multiparts)}
          (ss/all-attachment-objects statements))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -137,6 +137,14 @@
                  (validate-multiparts
                   statements
                   [multipart]))))
+        (testing "fails with missing attachment"
+          (is (= ::attachment/statement-attachment-missing
+                 (try (validate-multiparts
+                       statements
+                       []) ;; no attachments
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs ExceptionInfo) exi
+                        (-> exi ex-data :type))))))
         (testing "fails with left over multiparts"
           (is (= ::attachment/statement-attachment-mismatch
                  (try (validate-multiparts

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -74,5 +74,6 @@
                  (try (validate-statements-multiparts
                        statements
                        [multipart])
-                      (catch clojure.lang.ExceptionInfo exi
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs ExceptionInfo) exi
                         (-> exi ex-data :type))))))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -51,7 +51,7 @@
                                (.getBytes sig "UTF-8"))
                          :cljs sig)))
               :input-stream
-              slurp))))
+              #?(:clj slurp)))))
     (testing "invalid-sig"
       (let [invalid-sig (apply str (drop 10 sig))]
         (is (= ::attachment/invalid-signature-json

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -123,18 +123,33 @@
                       "length"      20
                       "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]]
         (testing "works with a dup multipart"
-          (is (= [statements [multipart
-                              multipart]]
+          (is (= [statements [multipart multipart]]
                  (validate-statements-multiparts
                   statements
                   [multipart
                    multipart]))))
-        #_(testing "works with a dedup multipart"
-            (is (= [statements [multipart]]
-                   (validate-statements-multiparts
-                    statements
-                    [multipart
-                     multipart]))))
+        (testing "fails with left over multiparts"
+          (is (= ::attachment/statement-attachment-mismatch
+                 (try (validate-statements-multiparts
+                       [s-template]
+                       [multipart])
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs ExceptionInfo) exi
+                        (-> exi ex-data :type)))))
+          (is (= ::attachment/statement-attachment-mismatch
+                 (try (validate-statements-multiparts
+                       [(assoc s-template
+                               "attachments"
+                               [{"usageType"   "https://example.com/usagetype"
+                                 "display"     {"en-US" "someattachment"}
+                                 "contentType" "application/octet-stream"
+                                 "length"      20
+                                 "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]
+                       [multipart
+                        multipart])
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs ExceptionInfo) exi
+                        (-> exi ex-data :type))))))
         (testing "fails with a single multipart"
           (is (= ::attachment/invalid-multipart-format
                  (try (validate-statements-multiparts

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -4,8 +4,69 @@
             [com.yetanalytics.test-support :refer [failures stc-opts]]
             [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment
              :as attachment
-             :refer [validate-statements-multiparts]])
+             :refer [decode-sig
+                     validate-sig
+                     validate-statements-multiparts]])
   #?(:clj (:import [java.io ByteArrayInputStream])))
+
+(deftest sig-test
+  (let [att-obj {"usageType" "http://adlnet.gov/expapi/attachments/signature",
+                 "display" {"en-US" "Signed by the Test Suite"},
+                 "description" {"en-US" "Signed by the Test Suite"},
+                 "contentType" "application/octet-stream",
+                 "length" 796,
+                 "sha2"
+                 "f7db3634a22ea2fe4de1fc519751046a3bdf1e5605a316a19343109bd6daa388"}
+        statement {"actor"
+                   {"objectType" "Agent",
+                    "name" "xAPI mbox",
+                    "mbox" "mailto:xapi@adlnet.gov"},
+                   "verb"
+                   {"id" "http://adlnet.gov/expapi/verbs/attended",
+                    "display" {"en-GB" "attended", "en-US" "attended"}},
+                   "object"
+                   {"objectType" "Activity",
+                    "id" "http://www.example.com/meetings/occurances/34534"},
+                   "id" "2e2f1ad7-8d10-4c73-ae6e-2842729e25ce",
+                   "attachments"
+                   [att-obj]}
+        sig "eyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjJlMmYxYWQ3LThkMTAtNGM3My1hZTZlLTI4NDI3MjllMjVjZSJ9.roBpi7viDC4DyNikcWtjuvfXEfrVqNtukVfOjoj-VEGbskcxc9H21GKQBsw3LxnpblIpiDPithCs2AOZK7RFy4vB9wsL5HmX8jpxGvGnYCWNEbVRGoYyntFWjF3wFtTaJMHvZLnirL6k1qhxdfJPcV2C-uc-FXC9AR4__xYbJioJDb37wvPtetD8x8YTdkMkM7nlv20GjV3YF-wa_cxt9hWVS-8LDikCswY6PpMLFR6eYeqIqrZxJQtqDhsZK3k28eHDxAnNB-dGoYeiSeFSbcToyVh4iz2lZGNUmfkltiVs7mLTVJNilU0Z41JIFrdYEGXEfYQwFmiIf5denL5_lg"
+        multipart {:content-type "application/octet-stream"
+                   :content-length 796
+                   :headers {"Content-Type"              "application/octet-stream"
+                             "Content-Transfer-Encoding" "binary"
+                             "X-Experience-API-Hash"     "f7db3634a22ea2fe4de1fc519751046a3bdf1e5605a316a19343109bd6daa388"}}]
+    (testing "decode-sig"
+      (= (dissoc statement "attachments")
+         (decode-sig sig)))
+    (testing "valid-sig"
+      (is
+       (= sig
+          (-> (validate-sig
+               statement
+               att-obj
+               (assoc multipart
+                      :input-stream
+                      #?(:clj (ByteArrayInputStream.
+                               (.getBytes sig "UTF-8"))
+                         :cljs sig)))
+              :input-stream
+              slurp))))
+    (testing "invalid-sig"
+      (let [invalid-sig (apply str (drop 10 sig))]
+        (is (= ::attachment/invalid-signature-json
+               (try
+                 (validate-sig
+                  statement
+                  att-obj
+                  (assoc multipart
+                         :input-stream
+                         #?(:clj (ByteArrayInputStream.
+                                  (.getBytes invalid-sig "UTF-8"))
+                            :cljs invalid-sig)))
+                 (catch #?(:clj clojure.lang.ExceptionInfo
+                           :cljs ExceptionInfo) exi
+                   (-> exi ex-data :type)))))))))
 
 (deftest validate-statements-multiparts-test
   (let [s-template {"id"          "78efaab3-1c65-4cb7-9289-f34e0594b274"
@@ -60,15 +121,20 @@
                       "display"     {"en-US" "someattachment"}
                       "contentType" "application/octet-stream"
                       "length"      20
-                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]
-            multiparts
-            [multipart
-             multipart]]
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]]
         (testing "works with a dup multipart"
-          (is (= [statements multiparts]
+          (is (= [statements [multipart
+                              multipart]]
                  (validate-statements-multiparts
                   statements
-                  multiparts))))
+                  [multipart
+                   multipart]))))
+        #_(testing "works with a dedup multipart"
+            (is (= [statements [multipart]]
+                   (validate-statements-multiparts
+                    statements
+                    [multipart
+                     multipart]))))
         (testing "fails with a single multipart"
           (is (= ::attachment/invalid-multipart-format
                  (try (validate-statements-multiparts

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -9,64 +9,72 @@
                      validate-multiparts]])
   #?(:clj (:import [java.io ByteArrayInputStream])))
 
+(def sig-attachment-object
+  {"usageType" "http://adlnet.gov/expapi/attachments/signature",
+   "display" {"en-US" "Signed by the Test Suite"},
+   "description" {"en-US" "Signed by the Test Suite"},
+   "contentType" "application/octet-stream",
+   "length" 796,
+   "sha2"
+   "f7db3634a22ea2fe4de1fc519751046a3bdf1e5605a316a19343109bd6daa388"})
+
+(def sig-statement
+  {"actor"
+   {"objectType" "Agent",
+    "name" "xAPI mbox",
+    "mbox" "mailto:xapi@adlnet.gov"},
+   "verb"
+   {"id" "http://adlnet.gov/expapi/verbs/attended",
+    "display" {"en-GB" "attended", "en-US" "attended"}},
+   "object"
+   {"objectType" "Activity",
+    "id" "http://www.example.com/meetings/occurances/34534"},
+   "id" "2e2f1ad7-8d10-4c73-ae6e-2842729e25ce",
+   "attachments"
+   [sig-attachment-object]})
+
+(def sig
+  "eyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjJlMmYxYWQ3LThkMTAtNGM3My1hZTZlLTI4NDI3MjllMjVjZSJ9.roBpi7viDC4DyNikcWtjuvfXEfrVqNtukVfOjoj-VEGbskcxc9H21GKQBsw3LxnpblIpiDPithCs2AOZK7RFy4vB9wsL5HmX8jpxGvGnYCWNEbVRGoYyntFWjF3wFtTaJMHvZLnirL6k1qhxdfJPcV2C-uc-FXC9AR4__xYbJioJDb37wvPtetD8x8YTdkMkM7nlv20GjV3YF-wa_cxt9hWVS-8LDikCswY6PpMLFR6eYeqIqrZxJQtqDhsZK3k28eHDxAnNB-dGoYeiSeFSbcToyVh4iz2lZGNUmfkltiVs7mLTVJNilU0Z41JIFrdYEGXEfYQwFmiIf5denL5_lg")
+
+(def sig-partial-multipart
+  {:content-type "application/octet-stream"
+   :content-length 796
+   :headers {"Content-Type"              "application/octet-stream"
+             "Content-Transfer-Encoding" "binary"
+             "X-Experience-API-Hash"     "f7db3634a22ea2fe4de1fc519751046a3bdf1e5605a316a19343109bd6daa388"}})
+
 (deftest sig-test
-  (let [att-obj {"usageType" "http://adlnet.gov/expapi/attachments/signature",
-                 "display" {"en-US" "Signed by the Test Suite"},
-                 "description" {"en-US" "Signed by the Test Suite"},
-                 "contentType" "application/octet-stream",
-                 "length" 796,
-                 "sha2"
-                 "f7db3634a22ea2fe4de1fc519751046a3bdf1e5605a316a19343109bd6daa388"}
-        statement {"actor"
-                   {"objectType" "Agent",
-                    "name" "xAPI mbox",
-                    "mbox" "mailto:xapi@adlnet.gov"},
-                   "verb"
-                   {"id" "http://adlnet.gov/expapi/verbs/attended",
-                    "display" {"en-GB" "attended", "en-US" "attended"}},
-                   "object"
-                   {"objectType" "Activity",
-                    "id" "http://www.example.com/meetings/occurances/34534"},
-                   "id" "2e2f1ad7-8d10-4c73-ae6e-2842729e25ce",
-                   "attachments"
-                   [att-obj]}
-        sig "eyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjJlMmYxYWQ3LThkMTAtNGM3My1hZTZlLTI4NDI3MjllMjVjZSJ9.roBpi7viDC4DyNikcWtjuvfXEfrVqNtukVfOjoj-VEGbskcxc9H21GKQBsw3LxnpblIpiDPithCs2AOZK7RFy4vB9wsL5HmX8jpxGvGnYCWNEbVRGoYyntFWjF3wFtTaJMHvZLnirL6k1qhxdfJPcV2C-uc-FXC9AR4__xYbJioJDb37wvPtetD8x8YTdkMkM7nlv20GjV3YF-wa_cxt9hWVS-8LDikCswY6PpMLFR6eYeqIqrZxJQtqDhsZK3k28eHDxAnNB-dGoYeiSeFSbcToyVh4iz2lZGNUmfkltiVs7mLTVJNilU0Z41JIFrdYEGXEfYQwFmiIf5denL5_lg"
-        multipart {:content-type "application/octet-stream"
-                   :content-length 796
-                   :headers {"Content-Type"              "application/octet-stream"
-                             "Content-Transfer-Encoding" "binary"
-                             "X-Experience-API-Hash"     "f7db3634a22ea2fe4de1fc519751046a3bdf1e5605a316a19343109bd6daa388"}}]
-    (testing "decode-sig"
-      (= (dissoc statement "attachments")
-         (decode-sig sig)))
-    (testing "valid-sig"
-      (is
-       (= sig
-          (-> (validate-sig
-               statement
-               att-obj
-               (assoc multipart
-                      :input-stream
-                      #?(:clj (ByteArrayInputStream.
-                               (.getBytes sig "UTF-8"))
-                         :cljs sig)))
-              :input-stream
-              #?(:clj slurp)))))
-    (testing "invalid-sig"
-      (let [invalid-sig (apply str (drop 10 sig))]
-        (is (= ::attachment/invalid-signature-json
-               (try
-                 (validate-sig
-                  statement
-                  att-obj
-                  (assoc multipart
-                         :input-stream
-                         #?(:clj (ByteArrayInputStream.
-                                  (.getBytes invalid-sig "UTF-8"))
-                            :cljs invalid-sig)))
-                 (catch #?(:clj clojure.lang.ExceptionInfo
-                           :cljs ExceptionInfo) exi
-                   (-> exi ex-data :type)))))))))
+  (testing "decode-sig"
+    (= (dissoc sig-statement "attachments")
+       (decode-sig sig)))
+  (testing "valid-sig"
+    (is
+     (= sig
+        (-> (validate-sig
+             sig-statement
+             sig-attachment-object
+             (assoc sig-partial-multipart
+                    :input-stream
+                    #?(:clj (ByteArrayInputStream.
+                             (.getBytes sig "UTF-8"))
+                       :cljs sig)))
+            :input-stream
+            #?(:clj slurp)))))
+  (testing "invalid-sig"
+    (let [invalid-sig (apply str (drop 10 sig))]
+      (is (= ::attachment/invalid-signature-json
+             (try
+               (validate-sig
+                sig-statement
+                sig-attachment-object
+                (assoc sig-partial-multipart
+                       :input-stream
+                       #?(:clj (ByteArrayInputStream.
+                                (.getBytes invalid-sig "UTF-8"))
+                          :cljs invalid-sig)))
+               (catch #?(:clj clojure.lang.ExceptionInfo
+                         :cljs ExceptionInfo) exi
+                 (-> exi ex-data :type))))))))
 
 (deftest validate-multiparts-test
   (let [s-template {"id"          "78efaab3-1c65-4cb7-9289-f34e0594b274"

--- a/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements/attachment_test.cljc
@@ -1,0 +1,78 @@
+(ns com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment-test
+  (:require [clojure.test :refer [deftest testing is] :include-macros true]
+            [clojure.spec.test.alpha :as stest :include-macros true]
+            [com.yetanalytics.test-support :refer [failures stc-opts]]
+            [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment
+             :as attachment
+             :refer [validate-statements-multiparts]])
+  #?(:clj (:import [java.io ByteArrayInputStream])))
+
+(deftest validate-statements-multiparts-test
+  (let [s-template {"id"          "78efaab3-1c65-4cb7-9289-f34e0594b274"
+                    "actor"       {"mbox"       "mailto:bob@example.com"
+                                   "objectType" "Agent"}
+                    "verb"        {"id" "https://example.com/verb"}
+                    "timestamp"   "2022-05-04T13:32:10.486195Z"
+                    "version"     "1.0.3"
+                    "object"      {"id" "https://example.com/activity"}}
+        multipart {:content-type "application/octet-stream"
+                   :content-length 20
+                   :headers {"Content-Type"              "application/octet-stream"
+                             "Content-Transfer-Encoding" "binary"
+                             "X-Experience-API-Hash"     "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}
+                   :input-stream #?(:clj (ByteArrayInputStream.
+                                          (.getBytes "some text\n some more" "UTF-8"))
+                                    :cljs "some text\n some more")}]
+    (testing "empty"
+      (is (= [[] []]
+             (validate-statements-multiparts
+              []
+              []))))
+
+    (testing "simple"
+      (let [statements
+            [(assoc s-template
+                    "attachments"
+                    [{"usageType"   "https://example.com/usagetype"
+                      "display"     {"en-US" "someattachment"}
+                      "contentType" "application/octet-stream"
+                      "length"      20
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]
+            multiparts
+            [multipart]]
+        (is (= [statements multiparts]
+               (validate-statements-multiparts
+                statements
+                multiparts)))))
+    (testing "dup reference"
+      ;; TODO: per this test, the lib currently requires that each referenced
+      ;; multipart be provided, even if they share a SHA.
+      ;; Is this what we intend?
+      (let [statements
+            [(assoc s-template
+                    "attachments"
+                    [{"usageType"   "https://example.com/usagetype"
+                      "display"     {"en-US" "someattachment"}
+                      "contentType" "application/octet-stream"
+                      "length"      20
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}
+                     {"usageType"   "https://example.com/usagetype"
+                      "display"     {"en-US" "someattachment"}
+                      "contentType" "application/octet-stream"
+                      "length"      20
+                      "sha2"        "7e0c4bbe6280e85cf8525dd7afe8d6ffe9051fbc5fadff71d4aded1ba4c74b53"}])]
+            multiparts
+            [multipart
+             multipart]]
+        (testing "works with a dup multipart"
+          (is (= [statements multiparts]
+                 (validate-statements-multiparts
+                  statements
+                  multiparts))))
+        (testing "fails with a single multipart"
+          (is (= ::attachment/invalid-multipart-format
+                 (try (validate-statements-multiparts
+                       statements
+                       [multipart])
+                      (catch clojure.lang.ExceptionInfo exi
+                        (-> exi ex-data :type))))))))))

--- a/src/test/com/yetanalytics/lrs/xapi/statements_test.cljc
+++ b/src/test/com/yetanalytics/lrs/xapi/statements_test.cljc
@@ -137,6 +137,12 @@
         (stest/check `ss/statement-ref?
                      {stc-opts {:num-tests 10 :max-size 3}})))))
 
+(deftest all-attachment-objects-test
+  (is (empty?
+       (failures
+        (stest/check `ss/all-attachment-objects
+                     {stc-opts {:num-tests 2 :max-size 2}})))))
+
 (deftest all-attachment-hashes-test
   (is (empty?
        (failures

--- a/src/test/com/yetanalytics/lrs_test.clj
+++ b/src/test/com/yetanalytics/lrs_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [com.yetanalytics.test-support :as support :refer [deftest-check-ns]]
             [com.yetanalytics.lrs.impl.memory :as mem]
-            [com.yetanalytics.lrs :refer [get-statements store-statements]]
+            [com.yetanalytics.lrs :as lrs]
             [clojure.string :as cs]
             [com.yetanalytics.datasim.input :as sim-input]
             [com.yetanalytics.datasim.sim :as sim]
@@ -27,32 +27,32 @@
               :input :json "dev-resources/datasim/input/tc3.json"))))
 
 ;; instrument LRS api fns throughout tests
-(stest/instrument `[get-about
-                    get-about-async
-                    set-document
-                    set-document-async
-                    get-document
-                    get-document-async
-                    get-document-ids
-                    get-document-ids-async
-                    delete-document
-                    delete-document-async
-                    delete-documents
-                    delete-documents-async
-                    get-activity
-                    get-activity-async
-                    get-person
-                    get-person-async
-                    store-statements
-                    store-statements-async
-                    get-statements
-                    get-statements-async
-                    consistent-through
-                    consistent-through-async
-                    authenticate
-                    authenticate-async
-                    authorize
-                    authorize-async])
+(stest/instrument `[lrs/get-about
+                    lrs/get-about-async
+                    lrs/set-document
+                    lrs/set-document-async
+                    lrs/get-document
+                    lrs/get-document-async
+                    lrs/get-document-ids
+                    lrs/get-document-ids-async
+                    lrs/delete-document
+                    lrs/delete-document-async
+                    lrs/delete-documents
+                    lrs/delete-documents-async
+                    lrs/get-activity
+                    lrs/get-activity-async
+                    lrs/get-person
+                    lrs/get-person-async
+                    lrs/store-statements
+                    lrs/store-statements-async
+                    lrs/get-statements
+                    lrs/get-statements-async
+                    lrs/consistent-through
+                    lrs/consistent-through-async
+                    lrs/authenticate
+                    lrs/authenticate-async
+                    lrs/authorize
+                    lrs/authorize-async])
 
 (deftest query-test
   (let [auth-id {:auth   {:no-op {}}
@@ -66,12 +66,12 @@
         ;; no normalization going on
         s-count        100
         lrs            (doto (mem/new-lrs {:statements-result-max s-count})
-                         (store-statements auth-id
-                                           (into [] (take s-count)
-                                                 test-statements)
-                                           []))
+                         (lrs/store-statements auth-id
+                                               (into [] (take s-count)
+                                                     test-statements)
+                                               []))
         get-ss         #(into []
-                              (get-in (get-statements lrs auth-id % #{"en-US"})
+                              (get-in (lrs/get-statements lrs auth-id % #{"en-US"})
                                       [:statement-result :statements]))
         ret-statements (get-ss {:limit 100})]
     (testing (format "%s valid return statements?" (count ret-statements))
@@ -166,10 +166,10 @@
                    (get "id"))]
         (is
          (:statement
-          (get-statements lrs
-                          auth-id
-                          {:statementId (cs/upper-case id)}
-                          #{"en-US"})))))
+          (lrs/get-statements lrs
+                              auth-id
+                              {:statementId (cs/upper-case id)}
+                              #{"en-US"})))))
 
     (testing "registration param is normalized"
       (let [reg (-> ret-statements
@@ -178,30 +178,30 @@
         (is reg)
         (is
          (not-empty
-          (get-in  (get-statements lrs
-                                   auth-id
-                                   {:registration (cs/upper-case reg)}
-                                   #{"en-US"})
+          (get-in  (lrs/get-statements lrs
+                                       auth-id
+                                       {:registration (cs/upper-case reg)}
+                                       #{"en-US"})
                    [:statement-result :statements])))))
 
     (testing "ID keys are normalized"
       (let [s   (first test-statements)
             id  (get s "id")
             lrs (doto (mem/new-lrs {:statements-result-max s-count})
-                  (store-statements
+                  (lrs/store-statements
                    auth-id
                    [(-> s
                         (update "id" cs/upper-case)
                         (update-in ["context" "registration"] cs/upper-case))]
                    []))]
-        (is (:statement (get-statements
+        (is (:statement (lrs/get-statements
                          lrs
                          auth-id
                          {:statementId id}
                          #{"en-US"})))
-          ;; This test will pass even w/o normalized IDs, but it makes sure we
-          ;; don't screw up the rel index
-        (is (not-empty (get-in (get-statements
+        ;; This test will pass even w/o normalized IDs, but it makes sure we
+        ;; don't screw up the rel index
+        (is (not-empty (get-in (lrs/get-statements
                                 lrs
                                 auth-id
                                 {:verb (get-in s ["verb" "id"])}
@@ -209,7 +209,7 @@
                                [:statement-result :statements])))
 
         (testing "reg index"
-          (is (not-empty (get-in (get-statements
+          (is (not-empty (get-in (lrs/get-statements
                                   lrs
                                   auth-id
                                   {:registration (get-in s ["context"
@@ -219,8 +219,8 @@
 
         (testing "original case is preserved"
           (is (= (cs/upper-case id)
-                 (get-in (get-statements lrs
-                                         auth-id
-                                         {:statementId id}
-                                         #{"en-US"})
+                 (get-in (lrs/get-statements lrs
+                                             auth-id
+                                             {:statementId id}
+                                             #{"en-US"})
                          [:statement "id"]))))))))

--- a/src/test/com/yetanalytics/test_runner.cljc
+++ b/src/test/com/yetanalytics/test_runner.cljc
@@ -14,6 +14,7 @@
    com.yetanalytics.lrs.impl.memory-test
    com.yetanalytics.lrs.pedestal.http.multipart-mixed-test
    com.yetanalytics.lrs.auth-test
+   com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment-test
    com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test))
 
 (defmethod test/report #?(:cljs [::test/default :begin-test-ns]
@@ -51,6 +52,7 @@
    'com.yetanalytics.lrs.impl.memory-test
    'com.yetanalytics.lrs.pedestal.http.multipart-mixed-test
    'com.yetanalytics.lrs.auth-test
+   'com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment-test
    'com.yetanalytics.lrs.pedestal.interceptor.xapi.statements.attachment.response-test))
 
 (defn ^:export -main []


### PR DESCRIPTION
[LRS-72]
Currently lrs expects attachment requests to contain one attachment part for every attachment reference in statement data. The spec language is ambiguous in this regard:  https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#requirements-for-attachment-statement-batches

It does however say that LRPs should normalize/deduplicate attachments being sent, so LRS (and its impls) should handle this.

Example with multiple references + deduplicated attachments that currently fails on our system:

<details>
  <summary>failing example</summary>

````http

POST /xapi/statements HTTP/1.1
X-Experience-API-Version: 1.0.3
Content-Type: multipart/mixed; boundary=105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Authorization: 
Host: localhost:8080
Connection: close
User-Agent: Paw/3.3.1 (Macintosh; OS X/12.3.1) GCDHTTPRequest
Content-Length: 1841


--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Content-Type:application/json

{
    "actor": {
        "mbox": "mailto:sample.agent@example.com",
        "name": "Sample Agent",
        "objectType": "Agent"
    },
    "verb": {
        "id": "http://adlnet.gov/expapi/verbs/answered",
        "display": {
            "en-US": "answered"
        }
    },
    "object": {
        "id": "http://www.example.com/tincan/activities/multipart",
        "objectType": "Activity",
        "definition": {
            "name": {
                "en-US": "Multi Part Activity"
            },
            "description": {
                "en-US": "Multi Part Activity Description"
            }
        }
    },
    "attachments": [
        {
            "usageType": "http://example.com/attachment-usage/test",
            "display": { "en-US": "A test attachment" },
            "description": { "en-US": "A test attachment (description)" },
            "contentType": "text/plain; charset=ascii",
            "length": 27,
            "sha2": "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"
        },
        {
            "usageType": "http://example.com/attachment-usage/test",
            "display": { "en-US": "A test attachment" },
            "description": { "en-US": "A test attachment (description)" },
            "contentType": "text/plain; charset=ascii",
            "length": 27,
            "sha2": "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"
        }
    ]
}
--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Content-Type:text/plain
Content-Transfer-Encoding:binary
X-Experience-API-Hash:495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a

here is a simple attachment
--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--


````
</details>


Example with multiple references and duplicated attachments that succeeds:

<details>
  <summary>passing example</summary>

````http

POST /xapi/statements HTTP/1.1
X-Experience-API-Version: 1.0.3
Content-Type: multipart/mixed; boundary=105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Authorization: 
Host: localhost:8080
Connection: close
User-Agent: Paw/3.3.1 (Macintosh; OS X/12.3.1) GCDHTTPRequest
Content-Length: 2081


--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Content-Type:application/json

{
    "actor": {
        "mbox": "mailto:sample.agent@example.com",
        "name": "Sample Agent",
        "objectType": "Agent"
    },
    "verb": {
        "id": "http://adlnet.gov/expapi/verbs/answered",
        "display": {
            "en-US": "answered"
        }
    },
    "object": {
        "id": "http://www.example.com/tincan/activities/multipart",
        "objectType": "Activity",
        "definition": {
            "name": {
                "en-US": "Multi Part Activity"
            },
            "description": {
                "en-US": "Multi Part Activity Description"
            }
        }
    },
    "attachments": [
        {
            "usageType": "http://example.com/attachment-usage/test",
            "display": { "en-US": "A test attachment" },
            "description": { "en-US": "A test attachment (description)" },
            "contentType": "text/plain; charset=ascii",
            "length": 27,
            "sha2": "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"
        },
        {
            "usageType": "http://example.com/attachment-usage/test",
            "display": { "en-US": "A test attachment" },
            "description": { "en-US": "A test attachment (description)" },
            "contentType": "text/plain; charset=ascii",
            "length": 27,
            "sha2": "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"
        }
    ]
}
--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Content-Type:text/plain
Content-Transfer-Encoding:binary
X-Experience-API-Hash:495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a

here is a simple attachment
--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
Content-Type:text/plain
Content-Transfer-Encoding:binary
X-Experience-API-Hash:495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a

here is a simple attachment
--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--

````

</details>

Additionally, passing to the impl is an open question:

> So this leads to another question, which is passing them to the impl: Efficiency would dictate that it not do what xapipe does (denormalize/duplicate by copying attachments so they are 1-1 with attachment objects) and just pass them normalized/deduplicated to the impl. This would however likely require some code changes on the impl to handle it (since they have been getting denormalized attachments since their inception)
> 
> So the options for passing to the impl are:
> 
> 1. denormalize/duplicate them (no changes to current impls, less efficient)
> 2. normalize/deduplicate them (some changes to current impls, more efficient)
> 3. pass them as received (pushes handing to impl) - This scares me, because a client could duplicate some but not all attachments and still not run afoul of the spec
> 

In its current state this PR takes option 2, but that's up for discussion!

[LRS-72]: https://yet.atlassian.net/browse/LRS-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ