### PR TITLE
LRS-75 Make multipart parsing more strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ LRS Applications implementing the `com.yetanalytics.lrs.protocol/-get-statements
 
 #### `PUT/POST /statements`
 
-xAPI clients can send statement data with arbitrary file attachments using the `multipart/mixed` Content-Type [per the spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#requirements-for-attachment-statement-batches). An attachment referenced in an xAPI statement (or substatement) that does not have a `fileUrl` property must be included *at least once* in the request body as a part identified by hash. In addition, multiple attachment objects, either in a single statement or across multiple statements in the same request, can refer to the same attachment, as recommended by the spec.
+xAPI clients can send statement data with arbitrary file attachments using the `multipart/mixed` Content-Type [per the spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#requirements-for-attachment-statement-batches).
+
+##### Format
+
+Request bodies should be formatted as `multipart/mixed` per [RFC 1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) with the following exceptions:
+
+* Preamble text is not supported, with the exception that a single leading CRLF before the first boundary is permitted for compatibility.
+* Epilogue text is not supported, but any number of empty trailing lines is permitted for compatibility.
+
+##### Normalization
+
+An attachment referenced in an xAPI statement (or substatement) that does not have a `fileUrl` property must be included *at least once* in the request body as a part identified by hash. In addition, multiple attachment objects, either in a single statement or across multiple statements in the same request, can refer to the same attachment, as recommended by the spec.
 
 In practice this means that duplicate attachments *may* be present on the request. `lrs` will normalize/deduplicate attachments before sending them to implementation code such that every attachment in the list has a distinct hash. See [this PR](https://github.com/yetanalytics/lrs/pull/81) for more information.
 

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -72,14 +72,15 @@
                  (boundary-pat-open boundary)))
          (loop [multiparts []]
            (if (.hasNext scanner)
-             (let [file-chunk ^String (.next scanner)
-                   _          (assert
-                      (not (cs/includes? file-chunk boundary))
-                      "Multipart parts must not include boundary.")
+             (let [^String file-chunk (.next scanner)
+                   _
+                   (assert
+                    (not (cs/includes? file-chunk boundary))
+                    "Multipart parts must not include boundary.")
                    [headers-str
-                    body-str] (cs/split file-chunk #"\r\n\r\n")
-                   headers    (parse-body-headers headers-str)
-                   body-bytes (.getBytes ^String body-str "UTF-8")]
+                    body-str]         (cs/split file-chunk #"\r\n\r\n")
+                   headers            (parse-body-headers headers-str)
+                   body-bytes         (.getBytes ^String body-str "UTF-8")]
                (recur
                 (conj multiparts
                       {:content-type   (get headers "Content-Type")

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -21,7 +21,7 @@
 ;; TODO: Test!!!
 (defn- make-boundary-pattern
   [boundary]
-  (re-pattern (str "(?m)\\R?^--" boundary "(?:--)?$\\R?")))
+  (re-pattern (str "(?m)(\\r\\n)?^--" boundary "(?:--)?$(\\r\\n)?")))
 
 (defn parse-parts [#?(:clj ^InputStream in
                       :cljs ^String in)
@@ -37,7 +37,7 @@
                                                  scanner
                                                  boundary-pattern))
                        :let [[headers-str
-                              body-str] (cs/split file-chunk #"\R{2}")
+                              body-str] (cs/split file-chunk #"\r\n\r\n")
                              headers    (parse-body-headers headers-str)
                              body-bytes (.getBytes ^String body-str "UTF-8")]]
                    {:content-type   (get headers "Content-Type")

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -41,7 +41,7 @@
 
 (defn- boundary-pat-close
   [boundary]
-  (format "\\r\\n--%s--(.|\r\n|\n)*$" boundary))
+  (format "\\r\\n--%s--(\r\n|\n)*$" boundary))
 
 (defn- assert-valid
   [test message]

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -73,22 +73,12 @@
        (assert-valid (= 1 (count open-re-pos))
                      "Only one opening boundary can be present"
                      ::invalid-one-opening-boundary)
-       (assert-valid (= 0 open-idx)
-                     "Opening boundary must begin the string"
-                     ::invalid-pos-opening-boundary)
        (assert-valid (<= 1 (count mid-re-pos))
                      "At least one mid boundary must be present"
                      ::invalid-at-least-one-mid-boundary)
        (assert-valid (= 1 (count close-re-pos))
                      "Only one closing boundary can be present"
                      ::invalid-one-closing-boundary)
-       (assert-valid (= (count body)
-                        (+ close-idx (count close-bound)))
-                     "Closing boundary must end string"
-                     ::invalid-pos-closing-boundary)
-       (assert-valid (distinct? all-pos)
-                     "All boundary positions must be distinct"
-                     ::invalid-distinct-boundary-pos)
        (for [[[idx-a
                bound-a :as a]
               [idx-b :as b]] (partition 2 1 all-pos)]

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -40,7 +40,7 @@
 
 (defn- boundary-pat-close
   [boundary]
-  (format "(?:\\r\\n--%s--(?:.|\\R)*$)" boundary))
+  (format "(?:\\r\\n--%s--(?:.|\r\n|\n)*$)" boundary))
 
 (defn make-boundary-pattern
   [boundary]

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -64,8 +64,8 @@
                 (throw (ex-info "Invalid Multipart Body"
                                 {:type ::invalid-multipart-body})))
               (catch Exception _
-                (throw (ex-info "Incomplete Multipart Request"
-                                {:type ::incomplete-multipart})))]
+                (throw (ex-info "Invalid Multipart Body"
+                                {:type ::invalid-multipart-body})))]
         :cljs [(catch js/Error jse
                  (throw (ex-info "Invalid Multipart Body"
                                  {:type ::invalid-multipart-body}

--- a/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/http/multipart_mixed.cljc
@@ -53,20 +53,18 @@
    (defn split-multiparts
      "Splits multipart body parts, ensuring start + end and at least 2 parts"
      [boundary body]
-     (let [[[open-idx open-bound]
-            :as open-re-pos] (u/re-pos
-                              (re-pattern
-                               (boundary-pat-open boundary))
-                              body)
+     (let [open-re-pos (u/re-pos
+                        (re-pattern
+                         (boundary-pat-open boundary))
+                        body)
            mid-re-pos (u/re-pos
                        (re-pattern
                         (boundary-pat-mid boundary))
                        body)
-           [[close-idx close-bound]
-            :as close-re-pos] (u/re-pos
-                               (re-pattern
-                                (boundary-pat-close boundary))
-                               body)
+           close-re-pos (u/re-pos
+                         (re-pattern
+                          (boundary-pat-close boundary))
+                         body)
            all-pos (concat open-re-pos
                            mid-re-pos
                            close-re-pos)]
@@ -80,8 +78,8 @@
                      "Only one closing boundary can be present"
                      ::invalid-one-closing-boundary)
        (for [[[idx-a
-               bound-a :as a]
-              [idx-b :as b]] (partition 2 1 all-pos)]
+               bound-a]
+              [idx-b]] (partition 2 1 all-pos)]
          (subs body
                (+ idx-a
                   (count bound-a))

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -145,13 +145,6 @@
                               :body
                               {:error
                                {:message "Invalid Multipart Body"}}})
-                      ::multipart/incomplete-multipart
-                      (assoc (chain/terminate ctx)
-                             :response
-                             {:status 400
-                              :body
-                              {:error
-                               {:message "Incomplete Multipart Request"}}})
                       ::multipart/too-much-content
                       (assoc (chain/terminate ctx)
                              :response

--- a/src/main/com/yetanalytics/lrs/util.cljc
+++ b/src/main/com/yetanalytics/lrs/util.cljc
@@ -20,8 +20,8 @@
    (defn regex-modifiers
      "Returns the modifiers of a regex, concatenated as a string."
      [re]
-     (str (if (.-multiline re) "m")
-          (if (.-ignoreCase re) "i"))))
+     (str (when (.-multiline re) "m")
+          (when (.-ignoreCase re) "i"))))
 
 #?(:cljs
    (defn re-pos

--- a/src/main/com/yetanalytics/lrs/util.cljc
+++ b/src/main/com/yetanalytics/lrs/util.cljc
@@ -14,3 +14,23 @@
        :cljs (.stringify js/JSON (clj->js x) nil 2))
     #?(:clj (json/generate-string x)
        :cljs (.stringify js/JSON (clj->js x)))))
+
+;; a la https://stackoverflow.com/questions/18735665/how-can-i-get-the-positions-of-regex-matches-in-clojurescript
+#?(:cljs
+   (defn regex-modifiers
+     "Returns the modifiers of a regex, concatenated as a string."
+     [re]
+     (str (if (.-multiline re) "m")
+          (if (.-ignoreCase re) "i"))))
+
+#?(:cljs
+   (defn re-pos
+     "Returns a vector of vectors, each subvector containing in order:
+   the position of the match, the matched string, and any groups
+   extracted from the match."
+     [re s]
+     (let [re (js/RegExp. (.-source re) (str "g" (regex-modifiers re)))]
+       (loop [res []]
+         (if-let [m (.exec re s)]
+           (recur (conj res (vec (cons (.-index m) m))))
+           res)))))

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -71,7 +71,7 @@
               (multipart/split-multiparts boundary (str "\r\n" body))))
        (is (= [statement-part
                sig-part]
-              (multipart/split-multiparts boundary (str body "\r\n foo bar")))))))
+              (multipart/split-multiparts boundary (str body "\r\n")))))))
 
 (defn- parse-body
   [body]
@@ -100,6 +100,13 @@
               #?(:clj #(update % :input-stream slurp)
                  :cljs identity)
               (parse-body leading-crlf-body))))))
+  (testing "allows trailing CRLF"
+    (let [leading-crlf-body (str body "\r\n")]
+      (is (= body-multiparts
+             (map
+              #?(:clj #(update % :input-stream slurp)
+                 :cljs identity)
+              (parse-body leading-crlf-body))))))
   (testing "doesn't allow bad line breaks"
     (let [bad-body (cs/replace body #"\r\n" "\n")]
       (is (= ::multipart/invalid-multipart-body
@@ -112,7 +119,7 @@
     (let [bad-body (str "preamble\r\n" body)]
       (is (= ::multipart/invalid-multipart-body
              (parse-body bad-body)))))
-  (testing "doesn't allow eplogue"
+  (testing "doesn't allow epilogue"
     (let [bad-body (str body "\r\nepilogue")]
       (is (= ::multipart/invalid-multipart-body
              (parse-body bad-body)))))

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -5,7 +5,10 @@
             [clojure.string :as cs]
             [com.yetanalytics.lrs.pedestal.interceptor.xapi.statements :as ss]
             #?(:cljs [fs]
-               :clj [clojure.java.io :as io])))
+               :clj [clojure.java.io :as io])
+            #?@(:cljs [[goog.string :refer [format]]
+                       [goog.string.format]]))
+  #?(:clj (:import [java.util Scanner])))
 
 (def header
   "Content-Type:application/octet-stream\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f")
@@ -17,25 +20,68 @@
             "Content-Transfer-Encoding" "binary"
             "X-Experience-API-Hash"     "20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f"}))))
 
-(def body
-  "\r\n---------------2199765322\r\nContent-Type:application/json\r\n\r\n{\"actor\":{\"objectType\":\"Agent\",\"name\":\"xAPI mbox\",\"mbox\":\"mailto:xapi@adlnet.gov\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/attended\",\"display\":{\"en-GB\":\"attended\",\"en-US\":\"attended\"}},\"object\":{\"objectType\":\"Activity\",\"id\":\"http://www.example.com/meetings/occurances/34534\"},\"id\":\"64343f68-6ebe-42d7-8bc1-a1c8c1be635b\",\"attachments\":[{\"usageType\":\"http://adlnet.gov/expapi/attachments/signature\",\"display\":{\"en-US\":\"Signed by the Test Suite\"},\"description\":{\"en-US\":\"Signed by the Test Suite\"},\"contentType\":\"application/octet-stream\",\"length\":796,\"sha2\":\"20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\"}]}\r\n---------------2199765322\r\nContent-Type:application/octet-stream\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\r\n\r\neyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjY0MzQzZjY4LTZlYmUtNDJkNy04YmMxLWExYzhjMWJlNjM1YiJ9.QWNSf1fViOwk78lkFd5IZaxd_JafCaCJEvjshLNvyPl3CfhC7CJmk8a6Pe3uX_38aI70xdSSIaMzx5Dwj0b7Pd6ZL3YNs-mx7xS4f3pICS3ELoUPOw53qlUKGmwRGzrKMDsdKj3QzGEh_AJu3zPDvRHo6wHYguqAcGi7HvnvpgC46tRMAHSeOucm29gYNJjQdt0UOLGkUKULn4Tt7n9ubuhVWRoqZvQ69_65HybTHpfzrC9Ef7PIY-8Q8MmXSZyvIxEKdn6pDEY0KPnjYB0oweARNevHW0Xt01-GFJiki0ddcgV34mfAFHsThbVHxGmIqK9o7wVMKlsiCOv0Vgr8uw\r\n---------------2199765322--")
+(def statement-part
+  "Content-Type:application/json\r\n\r\n{\"actor\":{\"objectType\":\"Agent\",\"name\":\"xAPI mbox\",\"mbox\":\"mailto:xapi@adlnet.gov\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/attended\",\"display\":{\"en-GB\":\"attended\",\"en-US\":\"attended\"}},\"object\":{\"objectType\":\"Activity\",\"id\":\"http://www.example.com/meetings/occurances/34534\"},\"id\":\"64343f68-6ebe-42d7-8bc1-a1c8c1be635b\",\"attachments\":[{\"usageType\":\"http://adlnet.gov/expapi/attachments/signature\",\"display\":{\"en-US\":\"Signed by the Test Suite\"},\"description\":{\"en-US\":\"Signed by the Test Suite\"},\"contentType\":\"application/octet-stream\",\"length\":796,\"sha2\":\"20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\"}]}")
+
+(def sig-part
+  "Content-Type:application/octet-stream\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\r\n\r\neyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjY0MzQzZjY4LTZlYmUtNDJkNy04YmMxLWExYzhjMWJlNjM1YiJ9.QWNSf1fViOwk78lkFd5IZaxd_JafCaCJEvjshLNvyPl3CfhC7CJmk8a6Pe3uX_38aI70xdSSIaMzx5Dwj0b7Pd6ZL3YNs-mx7xS4f3pICS3ELoUPOw53qlUKGmwRGzrKMDsdKj3QzGEh_AJu3zPDvRHo6wHYguqAcGi7HvnvpgC46tRMAHSeOucm29gYNJjQdt0UOLGkUKULn4Tt7n9ubuhVWRoqZvQ69_65HybTHpfzrC9Ef7PIY-8Q8MmXSZyvIxEKdn6pDEY0KPnjYB0oweARNevHW0Xt01-GFJiki0ddcgV34mfAFHsThbVHxGmIqK9o7wVMKlsiCOv0Vgr8uw")
 
 (def boundary "-------------2199765322")
 
+(def body
+  (format
+   "\r\n--%s\r\n%s\r\n--%s\r\n%s\r\n--%s--"
+   boundary
+   statement-part
+   boundary
+   sig-part
+   boundary))
+
+(deftest make-boundary-pattern-test
+  (testing "splits parts"
+    (is (= [""
+            statement-part
+            sig-part]
+           (cs/split body (multipart/make-boundary-pattern boundary))))))
+
+#?(:clj
+   (deftest scanner-boundary-test
+     (is (= [statement-part
+             sig-part]
+            (with-open [scanner (.useDelimiter
+                                 (Scanner. (io/input-stream (.getBytes body)))
+                                 (multipart/make-boundary-pattern boundary))]
+              (into [] (iterator-seq scanner)))))))
+
+(defn- parse-body
+  [body]
+  (try
+    #?(:clj (with-open [in (io/input-stream (.getBytes body "UTF-8"))]
+              (multipart/parse-parts in boundary))
+       :cljs (multipart/parse-parts body boundary))
+    (catch #?(:clj clojure.lang.ExceptionInfo
+              :cljs ExceptionInfo) exi
+      (-> exi ex-data :type))))
+
 (deftest parse-parts-test
-  (is (nil? (s/explain-data
-             (s/cat :statement-part ::ss/statement-part
-                    :multiparts (s/* ::ss/multipart))
-             #?(:clj (with-open [in (io/input-stream (.getBytes body "UTF-8"))]
-                       (multipart/parse-parts in boundary))
-                :cljs (multipart/parse-parts body boundary)))))
-  (testing "bad line breaks"
+  (testing "valid multipart body"
+    (is (nil? (s/explain-data
+               (s/cat :statement-part ::ss/statement-part
+                      :multiparts (s/* ::ss/multipart))
+               (parse-body body)))))
+  (testing "doesn't allow bad line breaks"
     (let [bad-body (cs/replace body #"\r\n" "\n")]
       (is (= ::multipart/invalid-multipart-body
-             (try
-               #?(:clj (with-open [in (io/input-stream (.getBytes bad-body "UTF-8"))]
-                         (multipart/parse-parts in boundary))
-                  :cljs (multipart/parse-parts bad-body boundary))
-               (catch #?(:clj clojure.lang.ExceptionInfo
-                         :cljs ExceptionInfo) exi
-                 (-> exi ex-data :type))))))))
+             (parse-body bad-body)))))
+  (testing "doesn't allow missing terminal boundary"
+    (let [bad-body (subs body 0 (- (count body) 2))]
+      (is (= ::multipart/invalid-multipart-body
+             (parse-body bad-body)))))
+  (testing "doesn't allow preamble"
+    (let [bad-body (str "preamble" body)]
+      (is (= ::multipart/invalid-multipart-body
+             (parse-body bad-body)))))
+  (testing "doesn't allow missing first boundary"
+    (let [bad-body (subs body 29)]
+      (is (= ::multipart/invalid-multipart-body
+             (parse-body bad-body))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -31,7 +31,7 @@
                 :cljs (multipart/parse-parts body boundary)))))
   (testing "bad line breaks"
     (let [bad-body (cs/replace body #"\r\n" "\n")]
-      (is (= ::multipart/incomplete-multipart
+      (is (= ::multipart/invalid-multipart-body
              (try
                #?(:clj (with-open [in (io/input-stream (.getBytes bad-body "UTF-8"))]
                          (multipart/parse-parts in boundary))

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -42,7 +42,14 @@
     (is (= [""
             statement-part
             sig-part]
-           (cs/split body (multipart/make-boundary-pattern boundary))))))
+           (cs/split body (multipart/make-boundary-pattern boundary)))))
+  (testing "ignores extras"
+    (is (= [""
+            statement-part
+            sig-part]
+           (cs/split
+            (str body "\r\n foo bar")
+            (multipart/make-boundary-pattern boundary))))))
 
 #?(:clj
    (deftest scanner-boundary-test

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -59,28 +59,19 @@
      "20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f"},
     :input-stream   sig-part-data}])
 
-(deftest make-boundary-pattern-test
-  (testing "splits parts"
-    (is (= [""
-            statement-part
-            sig-part]
-           (cs/split body (multipart/make-boundary-pattern boundary)))))
-  (testing "ignores extras"
-    (is (= [""
-            statement-part
-            sig-part]
-           (cs/split
-            (str body "\r\n foo bar")
-            (multipart/make-boundary-pattern boundary))))))
-
-#?(:clj
-   (deftest scanner-boundary-test
-     (is (= [statement-part
-             sig-part]
-            (with-open [scanner (.useDelimiter
-                                 (Scanner. (io/input-stream (.getBytes body)))
-                                 (multipart/make-boundary-pattern boundary))]
-              (into [] (iterator-seq scanner)))))))
+#?(:cljs
+   (deftest split-multiparts-test
+     (testing "splits parts"
+       (is (= [statement-part
+               sig-part]
+              (multipart/split-multiparts boundary body))))
+     (testing "ignores extras"
+       (is (= [statement-part
+               sig-part]
+              (multipart/split-multiparts boundary (str "\r\n" body))))
+       (is (= [statement-part
+               sig-part]
+              (multipart/split-multiparts boundary (str body "\r\n foo bar")))))))
 
 (defn- parse-body
   [body]

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -31,7 +31,7 @@
                 :cljs (multipart/parse-parts body boundary)))))
   (testing "bad line breaks"
     (let [bad-body (cs/replace body #"\r\n" "\n")]
-      (is (= ::multipart/invalid-multipart-body
+      (is (= ::multipart/incomplete-multipart
              (try
                #?(:clj (with-open [in (io/input-stream (.getBytes bad-body "UTF-8"))]
                          (multipart/parse-parts in boundary))

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -73,6 +73,15 @@
                sig-part]
               (multipart/split-multiparts boundary (str body "\r\n")))))))
 
+(deftest parse-part-test
+  (testing "Decodes valid bodies"
+    (is (= (first body-multiparts)
+           (-> (multipart/parse-part statement-part boundary)
+               #?(:clj (update :input-stream slurp)))))
+    (is (= (second body-multiparts)
+           (-> (multipart/parse-part sig-part boundary)
+               #?(:clj (update :input-stream slurp)))))))
+
 (defn- parse-body
   [body]
   (try

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -110,12 +110,12 @@
                  :cljs identity)
               (parse-body leading-crlf-body))))))
   (testing "allows trailing CRLF"
-    (let [leading-crlf-body (str body "\r\n")]
+    (let [trailing-crlf-body (str body "\r\n")]
       (is (= body-multiparts
              (map
               #?(:clj #(update % :input-stream slurp)
                  :cljs identity)
-              (parse-body leading-crlf-body))))))
+              (parse-body trailing-crlf-body))))))
   (testing "doesn't allow bad line breaks"
     (let [bad-body (cs/replace body #"\r\n" "\n")]
       (is (= ::multipart/invalid-multipart-body

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -7,8 +7,7 @@
             #?(:cljs [fs]
                :clj [clojure.java.io :as io])
             #?@(:cljs [[goog.string :refer [format]]
-                       [goog.string.format]]))
-  #?(:clj (:import [java.util Scanner])))
+                       [goog.string.format]])))
 
 (def header
   "Content-Type:application/octet-stream\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f")

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -20,11 +20,19 @@
             "Content-Transfer-Encoding" "binary"
             "X-Experience-API-Hash"     "20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f"}))))
 
+(def statement-part-data
+  "{\"actor\":{\"objectType\":\"Agent\",\"name\":\"xAPI mbox\",\"mbox\":\"mailto:xapi@adlnet.gov\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/attended\",\"display\":{\"en-GB\":\"attended\",\"en-US\":\"attended\"}},\"object\":{\"objectType\":\"Activity\",\"id\":\"http://www.example.com/meetings/occurances/34534\"},\"id\":\"64343f68-6ebe-42d7-8bc1-a1c8c1be635b\",\"attachments\":[{\"usageType\":\"http://adlnet.gov/expapi/attachments/signature\",\"display\":{\"en-US\":\"Signed by the Test Suite\"},\"description\":{\"en-US\":\"Signed by the Test Suite\"},\"contentType\":\"application/octet-stream\",\"length\":796,\"sha2\":\"20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\"}]}")
+
 (def statement-part
-  "Content-Type:application/json\r\n\r\n{\"actor\":{\"objectType\":\"Agent\",\"name\":\"xAPI mbox\",\"mbox\":\"mailto:xapi@adlnet.gov\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/attended\",\"display\":{\"en-GB\":\"attended\",\"en-US\":\"attended\"}},\"object\":{\"objectType\":\"Activity\",\"id\":\"http://www.example.com/meetings/occurances/34534\"},\"id\":\"64343f68-6ebe-42d7-8bc1-a1c8c1be635b\",\"attachments\":[{\"usageType\":\"http://adlnet.gov/expapi/attachments/signature\",\"display\":{\"en-US\":\"Signed by the Test Suite\"},\"description\":{\"en-US\":\"Signed by the Test Suite\"},\"contentType\":\"application/octet-stream\",\"length\":796,\"sha2\":\"20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\"}]}")
+  (str "Content-Type:application/json\r\n\r\n"
+       statement-part-data))
+
+(def sig-part-data
+  "eyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjY0MzQzZjY4LTZlYmUtNDJkNy04YmMxLWExYzhjMWJlNjM1YiJ9.QWNSf1fViOwk78lkFd5IZaxd_JafCaCJEvjshLNvyPl3CfhC7CJmk8a6Pe3uX_38aI70xdSSIaMzx5Dwj0b7Pd6ZL3YNs-mx7xS4f3pICS3ELoUPOw53qlUKGmwRGzrKMDsdKj3QzGEh_AJu3zPDvRHo6wHYguqAcGi7HvnvpgC46tRMAHSeOucm29gYNJjQdt0UOLGkUKULn4Tt7n9ubuhVWRoqZvQ69_65HybTHpfzrC9Ef7PIY-8Q8MmXSZyvIxEKdn6pDEY0KPnjYB0oweARNevHW0Xt01-GFJiki0ddcgV34mfAFHsThbVHxGmIqK9o7wVMKlsiCOv0Vgr8uw")
 
 (def sig-part
-  "Content-Type:application/octet-stream\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\r\n\r\neyJhbGciOiJSUzI1NiJ9.eyJhY3RvciI6eyJvYmplY3RUeXBlIjoiQWdlbnQiLCJuYW1lIjoieEFQSSBtYm94IiwibWJveCI6Im1haWx0bzp4YXBpQGFkbG5ldC5nb3YifSwidmVyYiI6eyJpZCI6Imh0dHA6Ly9hZGxuZXQuZ292L2V4cGFwaS92ZXJicy9hdHRlbmRlZCIsImRpc3BsYXkiOnsiZW4tR0IiOiJhdHRlbmRlZCIsImVuLVVTIjoiYXR0ZW5kZWQifX0sIm9iamVjdCI6eyJvYmplY3RUeXBlIjoiQWN0aXZpdHkiLCJpZCI6Imh0dHA6Ly93d3cuZXhhbXBsZS5jb20vbWVldGluZ3Mvb2NjdXJhbmNlcy8zNDUzNCJ9LCJpZCI6IjY0MzQzZjY4LTZlYmUtNDJkNy04YmMxLWExYzhjMWJlNjM1YiJ9.QWNSf1fViOwk78lkFd5IZaxd_JafCaCJEvjshLNvyPl3CfhC7CJmk8a6Pe3uX_38aI70xdSSIaMzx5Dwj0b7Pd6ZL3YNs-mx7xS4f3pICS3ELoUPOw53qlUKGmwRGzrKMDsdKj3QzGEh_AJu3zPDvRHo6wHYguqAcGi7HvnvpgC46tRMAHSeOucm29gYNJjQdt0UOLGkUKULn4Tt7n9ubuhVWRoqZvQ69_65HybTHpfzrC9Ef7PIY-8Q8MmXSZyvIxEKdn6pDEY0KPnjYB0oweARNevHW0Xt01-GFJiki0ddcgV34mfAFHsThbVHxGmIqK9o7wVMKlsiCOv0Vgr8uw")
+  (str "Content-Type:application/octet-stream\r\nContent-Transfer-Encoding:binary\r\nX-Experience-API-Hash:20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f\r\n\r\n"
+       sig-part-data))
 
 (def boundary "-------------2199765322")
 
@@ -72,10 +80,25 @@
 
 (deftest parse-parts-test
   (testing "valid multipart body"
-    (is (nil? (s/explain-data
-               (s/cat :statement-part ::ss/statement-part
-                      :multiparts (s/* ::ss/multipart))
-               (parse-body body)))))
+    (let [parse-result (parse-body body)]
+      (is (= [{:content-type   "application/json",
+               :content-length 629,
+               :headers        {"Content-Type" "application/json"},
+               :input-stream   statement-part-data}
+              {:content-type   "application/octet-stream",
+               :content-length 796,
+               :headers
+               {"Content-Type"              "application/octet-stream",
+                "Content-Transfer-Encoding" "binary",
+                "X-Experience-API-Hash"
+                "20a919870593a42d81370fcc23725b40e19bbafadb15498683ffd45adc82928f"},
+               :input-stream   sig-part-data}]
+             #?(:clj (map #(update % :input-stream slurp) parse-result)
+                :cljs parse-result)))
+      (is (nil? (s/explain-data
+                 (s/cat :statement-part ::ss/statement-part
+                        :multiparts (s/* ::ss/multipart))
+                 parse-result)))))
   (testing "doesn't allow bad line breaks"
     (let [bad-body (cs/replace body #"\r\n" "\n")]
       (is (= ::multipart/invalid-multipart-body

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -33,9 +33,9 @@
     (let [bad-body (cs/replace body #"\r\n" "\n")]
       (is (= ::multipart/invalid-multipart-body
              (try
-               #?(:clj (with-open [in (io/input-stream (.getBytes body "UTF-8"))]
+               #?(:clj (with-open [in (io/input-stream (.getBytes bad-body "UTF-8"))]
                          (multipart/parse-parts in boundary))
-                  :cljs (multipart/parse-parts body boundary))
+                  :cljs (multipart/parse-parts bad-body boundary))
                (catch #?(:clj clojure.lang.ExceptionInfo
                          :cljs ExceptionInfo) exi
                  (-> exi ex-data :type))))))))

--- a/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
+++ b/src/test/com/yetanalytics/lrs/pedestal/http/multipart_mixed_test.cljc
@@ -109,7 +109,11 @@
       (is (= ::multipart/invalid-multipart-body
              (parse-body bad-body)))))
   (testing "doesn't allow preamble"
-    (let [bad-body (str "preamble" body)]
+    (let [bad-body (str "preamble\r\n" body)]
+      (is (= ::multipart/invalid-multipart-body
+             (parse-body bad-body)))))
+  (testing "doesn't allow eplogue"
+    (let [bad-body (str body "\r\nepilogue")]
       (is (= ::multipart/invalid-multipart-body
              (parse-body bad-body)))))
   (testing "doesn't allow missing first boundary"


### PR DESCRIPTION
[LRS-74] [LRS-75] Apparently our clj multipart parsing allows _either_ a crlf or just an lf. That seems wrong! ~~Cljs is more discerning.~~ Actually it shared some of the same issues with boundary checking, and this is addressed now.

This PR:
* Requires proper CRLF line breaks per [RFC 1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html)
* Explicitly disallows preamble + epilogue text
* Properly verifies the presence of start + end boundaries
  * Reworked clj `java.util.Scanner` implementation
  * Transitioned cljs `clojure.string/split`-based strategy to explicit boundary mapping
* Adds an implementation note to the README
* Limits multipart body errors to a single keyword
* Removed reliance on runtime asserts

[LRS-74]: https://yet.atlassian.net/browse/LRS-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LRS-75]: https://yet.atlassian.net/browse/LRS-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ