### PR TITLE
exclude msgpack to clear CVE-2022-41719

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,10 @@
   com.yetanalytics/xapi-schema {:mvn/version "1.2.0"
                                 :exclusions [org.clojure/clojurescript]}
   cheshire/cheshire {:mvn/version "5.10.1"}
-  io.pedestal/pedestal.service {:mvn/version "0.5.10"}
+  io.pedestal/pedestal.service {:mvn/version "0.5.10"
+                                ;; exclude msgpack (via tools.analyzer)
+                                ;; clears CVE-2022-41719
+                                :exclusions [org.msgpack/msgpack]}
   macchiato/core {:mvn/version "0.2.17"
                   :exclusions [funcool/cuerdas]}
   funcool/cuerdas {:mvn/version "2020.03.26-2"}


### PR DESCRIPTION
Probably an FP, but we don't use it