### PR TITLE
Lock conformance tests to 1.0.3

### DIFF
--- a/src/test/com/yetanalytics/conformance_test/clj/async.clj
+++ b/src/test/com/yetanalytics/conformance_test/clj/async.clj
@@ -15,6 +15,7 @@
                "-e"
                "http://localhost:8080/xapi"
                "-b"
-               "-z")]
+               "-z"
+               "-x" "1.0.3")]
       (http/stop s)
       (is (true? ret)))))

--- a/src/test/com/yetanalytics/conformance_test/clj/sync.clj
+++ b/src/test/com/yetanalytics/conformance_test/clj/sync.clj
@@ -15,6 +15,7 @@
                "-e"
                "http://localhost:8080/xapi"
                "-b"
-               "-z")]
+               "-z"
+               "-x" "1.0.3")]
       (http/stop s)
       (is (true? ret)))))

--- a/src/test/com/yetanalytics/conformance_test/cljs.clj
+++ b/src/test/com/yetanalytics/conformance_test/cljs.clj
@@ -51,6 +51,7 @@
                    "-e"
                    "http://localhost:8080/xapi"
                    "-b"
-                   "-z")]
+                   "-z"
+                   "-x" "1.0.3")]
       (stop-fn)
       (is (true? ret)))))


### PR DESCRIPTION
With the 2.0 conformance tests merged, they now default to 2.0.0 so lock the tests down to 1.0.3 which is what we currently support.