### PR TITLE
SQL-215 Support Attachment and Document Scanning

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,7 +42,8 @@
                               :sha "423bd6c301ce8503f5c18b43df098bbe64f8f1ab"}
     com.yetanalytics/lrs-test-runner
     {:git/url "https://github.com/yetanalytics/lrs-test-runner.git"
-     :sha "0fcd42854f9c79a043c13d436d629826bfc5133d"}}}
+     :sha "0fcd42854f9c79a043c13d436d629826bfc5133d"}
+    babashka/babashka.curl {:mvn/version "0.1.2"}}}
   ;; bench utils for LRS implementations
   :bench
   {:extra-paths ["src/bench"]

--- a/dev-resources/attachments/attachment_post_body.txt
+++ b/dev-resources/attachments/attachment_post_body.txt
@@ -1,0 +1,45 @@
+--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
+Content-Type:application/json
+
+{
+    "actor": {
+        "mbox": "mailto:sample.agent@example.com",
+        "name": "Sample Agent",
+        "objectType": "Agent"
+    },
+    "verb": {
+        "id": "http://adlnet.gov/expapi/verbs/answered",
+        "display": {
+            "en-US": "answered"
+        }
+    },
+    "object": {
+        "id": "http://www.example.com/tincan/activities/multipart",
+        "objectType": "Activity",
+        "definition": {
+            "name": {
+                "en-US": "Multi Part Activity"
+            },
+            "description": {
+                "en-US": "Multi Part Activity Description"
+            }
+        }
+    },
+    "attachments": [
+        {
+            "usageType": "http://example.com/attachment-usage/test",
+            "display": { "en-US": "A test attachment" },
+            "description": { "en-US": "A test attachment (description)" },
+            "contentType": "text/plain; charset=ascii",
+            "length": 27,
+            "sha2": "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"
+        }
+    ]
+}
+--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0
+Content-Type:text/plain
+Content-Transfer-Encoding:binary
+X-Experience-API-Hash:495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a
+
+here is a simple attachment
+--105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0--

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
@@ -2,7 +2,10 @@
   "Document Interceptors"
   (:require
    [io.pedestal.interceptor.chain :as chain]
-   #?(:clj [clojure.java.io :as io]))
+   [com.yetanalytics.lrs.util :as u]
+   #?(:clj [clojure.java.io :as io])
+   #?@(:cljs [[goog.string :refer [format]]
+              [goog.string.format]]))
   #?(:clj (:import [java.io ByteArrayOutputStream ByteArrayInputStream])))
 
 #?(:clj
@@ -31,11 +34,12 @@
          (assoc (chain/terminate ctx)
                 :response
                 {:status 400
-                 :headers {"content-type" "application/json"}
-                 :body {:error
-                        {:message
-                         (format "Document scan failed, Error: %s"
-                                 (:message scan-error))}}})
+                 :headers {"Content-Type" "application/json"}
+                 :body (u/json-string
+                        {:error
+                         {:message
+                          (format "Document scan failed, Error: %s"
+                                  (:message scan-error))}})})
          (assoc-in ctx
                    [:request :body]
                    #?(:clj (ByteArrayInputStream. body-bytes)

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
@@ -1,0 +1,38 @@
+(ns com.yetanalytics.lrs.pedestal.interceptor.xapi.document
+  "Document Interceptors"
+  (:require
+   [io.pedestal.interceptor.chain :as chain]
+   #?(:clj [clojure.java.io :as io]))
+  #?(:clj (:import [java.io ByteArrayOutputStream ByteArrayInputStream])))
+
+#?(:clj
+   (defn stream->bytes
+     [input-stream]
+     (let [baos (ByteArrayOutputStream.)]
+       (io/copy input-stream baos)
+       (.toByteArray baos))))
+
+(defn scan-document
+  "Return an interceptor that will scan document request bodies given a
+  file-scanner fn. Reads body into a byte array (in clojure)"
+  [file-scanner]
+  {:name ::scan-document
+   :enter
+   (fn [ctx]
+     (let [body-bytes (-> ctx
+                          (get-in [:request :body])
+                          #?(:clj stream->bytes :cljs identity))]
+       (if-let [scan-error (file-scanner
+                            #?(:clj (ByteArrayInputStream. body-bytes)
+                               :cljs body-bytes))]
+         (assoc (chain/terminate ctx)
+                :response
+                {:status 400
+                 :body {:error
+                        {:message
+                         (format "Document scan failed, Error: %s"
+                                 (:message scan-error))}}})
+         (assoc-in ctx
+                   [:request :body]
+                   #?(:clj (ByteArrayInputStream. body-bytes)
+                      :cljs body-bytes)))))})

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
@@ -31,6 +31,7 @@
          (assoc (chain/terminate ctx)
                 :response
                 {:status 400
+                 :headers {"content-type" "application/json"}
                  :body {:error
                         {:message
                          (format "Document scan failed, Error: %s"

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/document.cljc
@@ -22,9 +22,12 @@
      (let [body-bytes (-> ctx
                           (get-in [:request :body])
                           #?(:clj stream->bytes :cljs identity))]
-       (if-let [scan-error (file-scanner
-                            #?(:clj (ByteArrayInputStream. body-bytes)
-                               :cljs body-bytes))]
+       (if-let [scan-error (try
+                             (file-scanner
+                              #?(:clj (ByteArrayInputStream. body-bytes)
+                                 :cljs body-bytes))
+                             (catch #?(:clj Exception :cljs js/Error) _
+                               {:message "Scan Error"}))]
          (assoc (chain/terminate ctx)
                 :response
                 {:status 400

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -253,6 +253,7 @@
                                      {:message "Scan Error"})))))
                         not-empty)]
          (do
+           ;; Delete (possibly) unsafe tempfiles
            (attachment/delete-attachments! attachments)
            (assoc (chain/terminate ctx)
                   :response

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -252,10 +252,11 @@
            (assoc (chain/terminate ctx)
                   :response
                   {:status 400
-                   :body {:error {:message
-                                  (format "Scan failed, Errors: %s"
-                                          (cs/join ", "
-                                                   (map :message attachment-errors)))}}}))
+                   :body {:error
+                          {:message
+                           (format "Attachment scan failed, Errors: %s"
+                                   (cs/join ", "
+                                            (map :message attachment-errors)))}}}))
          ctx)))})
 
 (def set-consistent-through

--- a/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/interceptor/xapi/statements.cljc
@@ -245,11 +245,12 @@
      (let [attachments (get-in ctx [:xapi :xapi.statements/attachments])]
        (if-let [attachment-errors
                 (some-> attachments
-                        (->> (keep (fn [{:keys [content]}]
-                                     (try
-                                       (file-scanner content)
-                                       (catch #?(:clj Exception :cljs js/Error) _
-                                         {:message "Scan Error"})))))
+                        (->>
+                         (keep (fn [{:keys [content]}]
+                                 (try
+                                   (file-scanner content)
+                                   (catch #?(:clj Exception :cljs js/Error) _
+                                     {:message "Scan Error"})))))
                         not-empty)]
          (do
            (attachment/delete-attachments! attachments)
@@ -259,8 +260,9 @@
                    :body {:error
                           {:message
                            (format "Attachment scan failed, Errors: %s"
-                                   (cs/join ", "
-                                            (map :message attachment-errors)))}}}))
+                                   (cs/join
+                                    ", "
+                                    (map :message attachment-errors)))}}}))
          ctx)))})
 
 (def set-consistent-through

--- a/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
@@ -43,28 +43,28 @@
         :route-name (keyword route-name-ns (name method))]
        (let [doc-params-interceptor
              (xapi-i/params-interceptor
-                   (case resource-tuple
-                     ["activities" "state"]
-                     (case method
-                       :put    :xapi.activities.state.PUT.request/params
-                       :post   :xapi.activities.state.POST.request/params
-                       :get    :xapi.activities.state.GET.request/params
-                       :head   :xapi.activities.state.GET.request/params
-                       :delete :xapi.activities.state.DELETE.request/params)
-                     ["activities" "profile"]
-                     (case method
-                       :put    :xapi.activities.profile.PUT.request/params
-                       :post   :xapi.activities.profile.POST.request/params
-                       :get    :xapi.activities.profile.GET.request/params
-                       :head   :xapi.activities.profile.GET.request/params
-                       :delete :xapi.activities.profile.DELETE.request/params)
-                     ["agents"     "profile"]
-                     (case method
-                       :put    :xapi.agents.profile.PUT.request/params
-                       :post   :xapi.agents.profile.POST.request/params
-                       :get    :xapi.agents.profile.GET.request/params
-                       :head   :xapi.agents.profile.GET.request/params
-                       :delete :xapi.agents.profile.DELETE.request/params)))
+              (case resource-tuple
+                ["activities" "state"]
+                (case method
+                  :put    :xapi.activities.state.PUT.request/params
+                  :post   :xapi.activities.state.POST.request/params
+                  :get    :xapi.activities.state.GET.request/params
+                  :head   :xapi.activities.state.GET.request/params
+                  :delete :xapi.activities.state.DELETE.request/params)
+                ["activities" "profile"]
+                (case method
+                  :put    :xapi.activities.profile.PUT.request/params
+                  :post   :xapi.activities.profile.POST.request/params
+                  :get    :xapi.activities.profile.GET.request/params
+                  :head   :xapi.activities.profile.GET.request/params
+                  :delete :xapi.activities.profile.DELETE.request/params)
+                ["agents"     "profile"]
+                (case method
+                  :put    :xapi.agents.profile.PUT.request/params
+                  :post   :xapi.agents.profile.POST.request/params
+                  :get    :xapi.agents.profile.GET.request/params
+                  :head   :xapi.agents.profile.GET.request/params
+                  :delete :xapi.agents.profile.DELETE.request/params)))
              params-interceptors
              (cond-> [doc-params-interceptor]
                ;; Scan files if scanner is present on PUT/POST

--- a/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes.cljc
@@ -41,9 +41,8 @@
         method
         method-not-allowed
         :route-name (keyword route-name-ns (name method))]
-       (let [params-interceptors
-             (cond->
-                 [(xapi-i/params-interceptor
+       (let [doc-params-interceptor
+             (xapi-i/params-interceptor
                    (case resource-tuple
                      ["activities" "state"]
                      (case method
@@ -65,7 +64,9 @@
                        :post   :xapi.agents.profile.POST.request/params
                        :get    :xapi.agents.profile.GET.request/params
                        :head   :xapi.agents.profile.GET.request/params
-                       :delete :xapi.agents.profile.DELETE.request/params)))]
+                       :delete :xapi.agents.profile.DELETE.request/params)))
+             params-interceptors
+             (cond-> [doc-params-interceptor]
                ;; Scan files if scanner is present on PUT/POST
                (and file-scanner
                     (contains? #{:put :post} method))

--- a/src/test/com/yetanalytics/conformance_test/clj/async.clj
+++ b/src/test/com/yetanalytics/conformance_test/clj/async.clj
@@ -15,6 +15,7 @@
                "-e"
                "http://localhost:8080/xapi"
                "-b"
-               "-z")]
+               "-z"
+               "-x" "1.0.3")]
       (http/stop s)
       (is (true? ret)))))

--- a/src/test/com/yetanalytics/conformance_test/clj/sync.clj
+++ b/src/test/com/yetanalytics/conformance_test/clj/sync.clj
@@ -15,6 +15,7 @@
                "-e"
                "http://localhost:8080/xapi"
                "-b"
-               "-z")]
+               "-z"
+               "-x" "1.0.3")]
       (http/stop s)
       (is (true? ret)))))

--- a/src/test/com/yetanalytics/conformance_test/cljs.clj
+++ b/src/test/com/yetanalytics/conformance_test/cljs.clj
@@ -51,6 +51,7 @@
                    "-e"
                    "http://localhost:8080/xapi"
                    "-b"
-                   "-z")]
+                   "-z"
+                   "-x" "1.0.3")]
       (stop-fn)
       (is (true? ret)))))

--- a/src/test/com/yetanalytics/lrs/scan_test.clj
+++ b/src/test/com/yetanalytics/lrs/scan_test.clj
@@ -1,0 +1,79 @@
+(ns com.yetanalytics.lrs.scan-test
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [babashka.curl :as curl]
+            [io.pedestal.http :as http]
+            [com.yetanalytics.test-support :as support]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(def attachment-post-params
+  {:basic-auth ["username" "password"]
+   :headers
+   {"X-Experience-API-Version" "1.0.3"
+    "Content-Type"
+    "multipart/mixed; boundary=105423a5219f5a63362a375ba7a64a8f234da19c7d01e56800c3c64b26bb2fa0"}
+   :body       (slurp "dev-resources/attachments/attachment_post_body.txt")
+   :throw      false})
+
+(def doc-post-params
+  {:basic-auth ["username" "password"]
+   :headers    {"X-Experience-API-Version" "1.0.3"}
+   :query-params
+   {"activityId" "http://www.example.com/activityId/hashset"
+    "agent"
+    "{\"objectType\":\"Agent\",\"account\":{\"homePage\":\"http://www.example.com/agentId/1\",\"name\":\"Rick James\"}}"
+    "stateId"    "f8128f68-74e2-4951-8c5f-ef7cce73b4ff"}
+   :body       "I'm a little teapot"
+   :throw      false})
+
+(deftest scan-test
+  (testing "File/Document Scanning"
+    ;; Stub out a scanner that always fails
+    (testing "Failure"
+      (let [server (support/test-server
+                    :route-opts
+                    {:file-scanner
+                     (fn [in]
+                       (slurp in)
+                       {:message "Scan Fail!"})})]
+        (try
+          (http/start server)
+          (testing "Attachment"
+            (is (= {:status 400
+                    :body   "{\"error\":{\"message\":\"Attachment scan failed, Errors: Scan Fail!\"}}"}
+                   (select-keys
+                    (curl/post
+                     "http://localhost:8080/xapi/statements"
+                     attachment-post-params)
+                    [:body :status]))))
+          (testing "Document"
+            (is (= {:status 400
+                    :body   "{\"error\":{\"message\":\"Document scan failed, Error: Scan Fail!\"}}"}
+                   (select-keys
+                    (curl/post
+                     "http://localhost:8080/xapi/activities/state"
+                     doc-post-params)
+                    [:body :status]))))
+          (finally
+            (http/stop server)))))
+    (testing "Success"
+      (let [server (support/test-server)]
+        (try
+          (http/start server)
+          (testing "Attachment"
+            (is (= 200
+                   (:status
+                    (curl/post
+                     "http://localhost:8080/xapi/statements"
+                     attachment-post-params)))))
+          (testing "Document"
+            (is (= 204
+                   (:status
+                    (curl/post
+                     "http://localhost:8080/xapi/activities/state"
+                     doc-post-params)))))
+          (finally
+            (http/stop server)))))))

--- a/src/test/com/yetanalytics/lrs/scan_test.clj
+++ b/src/test/com/yetanalytics/lrs/scan_test.clj
@@ -59,8 +59,14 @@
                     [:body :status]))))
           (finally
             (http/stop server)))))
+    ;; And a scanner that always passes
     (testing "Success"
-      (let [server (support/test-server)]
+      (let [server (support/test-server
+                    :route-opts
+                    {:file-scanner
+                     (fn [in]
+                       (slurp in)
+                       nil)})]
         (try
           (http/start server)
           (testing "Attachment"

--- a/src/test/com/yetanalytics/test_runner.cljc
+++ b/src/test/com/yetanalytics/test_runner.cljc
@@ -4,8 +4,9 @@
    clojure.test.check.properties
    [clojure.test :as test
     :refer [run-tests] :include-macros true]
-   #?(:clj com.yetanalytics.lrs-test
-      :cljs [cljs.nodejs :refer [process]])
+   #?@(:clj [com.yetanalytics.lrs-test
+             com.yetanalytics.lrs.scan-test]
+       :cljs [[cljs.nodejs :refer [process]]])
    com.yetanalytics.lrs.xapi.activities-test
    com.yetanalytics.lrs.xapi.agents-test
    com.yetanalytics.lrs.xapi.document-test
@@ -43,7 +44,8 @@
 (defn- run-lrs-tests
   []
   (run-tests
-   #?(:clj 'com.yetanalytics.lrs-test)
+   #?@(:clj ['com.yetanalytics.lrs-test
+             'com.yetanalytics.lrs.scan-test])
    'com.yetanalytics.lrs.xapi.activities-test
    'com.yetanalytics.lrs.xapi.agents-test
    'com.yetanalytics.lrs.xapi.document-test


### PR DESCRIPTION
[SQL-215] Allow impl-submitted `file-scanner` function to scan incoming attachments and documents.

[SQL-215]: https://yet.atlassian.net/browse/SQL-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ