### PR TITLE
fix: /PUT state not following spec with 409 - Conflict

### DIFF
--- a/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
@@ -306,17 +306,18 @@
                                      lrs
                                      ctx
                                      auth-identity params))]
-                  (if (and (or
-                            ;; In 2.0, no headers ok for no doc
-                            (= "2.0.0"
-                               (:com.yetanalytics.lrs/version ctx))
-                            ;; prior tests seem to want this for everything but
-                            ;; profiles
-                            (not (#{:xapi.activities.profile.PUT.request/params
-                                    :xapi.agents.profile.PUT.request/params}
-                                  params-type)))
-                           (not (:error doc-res))
-                           (nil? (:document doc-res)))
+                  (if (and (not (:error doc-res))
+                           (or
+                            ;; State resources are exempt from concurrency
+                            ;; header requirements in all xAPI versions
+                            (= :xapi.activities.state.PUT.request/params
+                               params-type)
+                            (and (nil? (:document doc-res))
+                                 (or (= "2.0.0"
+                                        (:com.yetanalytics.lrs/version ctx))
+                                     (not (#{:xapi.activities.profile.PUT.request/params
+                                             :xapi.agents.profile.PUT.request/params}
+                                           params-type))))))
                     (put-response ctx
                                   (a/<! (lrs/set-document-async
                                          lrs
@@ -344,17 +345,18 @@
                              lrs
                              ctx
                              auth-identity params)]
-                (if (and (or
-                          ;; In 2.0, no headers ok for no doc
-                          (= "2.0.0"
-                             (:com.yetanalytics.lrs/version ctx))
-                          ;; prior tests seem to want this for everything but
-                          ;; profiles
-                          (not (#{:xapi.activities.profile.PUT.request/params
-                                  :xapi.agents.profile.PUT.request/params}
-                                params-type)))
-                         (not (:error doc-res))
-                         (nil? (:document doc-res)))
+                (if (and (not (:error doc-res))
+                         (or
+                          ;; State resources are exempt from concurrency
+                          ;; header requirements in all xAPI versions
+                          (= :xapi.activities.state.PUT.request/params
+                             params-type)
+                          (and (nil? (:document doc-res))
+                               (or (= "2.0.0"
+                                      (:com.yetanalytics.lrs/version ctx))
+                                   (not (#{:xapi.activities.profile.PUT.request/params
+                                           :xapi.agents.profile.PUT.request/params}
+                                         params-type))))))
                   (put-response ctx
                                 (lrs/set-document
                                  lrs

--- a/src/test/com/yetanalytics/lrs_test.clj
+++ b/src/test/com/yetanalytics/lrs_test.clj
@@ -284,3 +284,43 @@
           "2.0.0" 200)
         (finally
           (http/stop lrs))))))
+
+(def agent-json
+  "{\"objectType\":\"Agent\",\"account\":{\"homePage\":\"http://www.example.com/agentId/1\",\"name\":\"Rick James\"}}")
+
+(defn- put-document
+  "PUT a document to the given url with query-params, version header, and body."
+  [url query-params version body]
+  (curl/put
+   url
+   {:basic-auth    ["username" "password"]
+    :headers       {"X-Experience-API-Version" version
+                    "Content-Type"             "application/octet-stream"}
+    :query-params  query-params
+    :body          body
+    :throw         false}))
+
+(deftest document-concurrency-test
+  (testing "Document PUT concurrency without If-Match/If-None-Match headers"
+    (let [server (support/test-server :port 8081)]
+      (try
+        (http/start server)
+        ;; https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md?plain=1#L1424
+        ;; State resources: xAPI 1.0.3 and 2.0 exempt state from concurrency
+        ;; header requirements, so PUTs without headers should always go through.
+        (testing "xAPI 2.0.0 - state: PUTs without concurrency headers go through"
+          (let [params {"activityId" "http://www.example.com/activity/1"
+                        "agent"      agent-json
+                        "stateId"    "concurrency-test-200-state"}
+                url    "http://localhost:8081/xapi/activities/state"]
+            (is (= 204 (:status (put-document url params "2.0.0" "first"))))
+            (is (= 204 (:status (put-document url params "2.0.0" "second"))))))
+        (testing "xAPI 1.0.3 - state: PUTs without concurrency headers go through"
+          (let [params {"activityId" "http://www.example.com/activity/2"
+                        "agent"      agent-json
+                        "stateId"    "concurrency-test-103-state"}
+                url    "http://localhost:8081/xapi/activities/state"]
+            (is (= 204 (:status (put-document url params "1.0.3" "first"))))
+            (is (= 204 (:status (put-document url params "1.0.3" "second"))))))
+        (finally
+          (http/stop server))))))


### PR DESCRIPTION
## Problem

State resources (`/xapi/activities/state`) were incorrectly subject to concurrency header requirements (`If-Match` / `If-None-Match`) when a document already existed. Per the [xAPI 1.0.3 spec §3.1](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md?plain=1#L1424) and xAPI 2.0.0, state resources are explicitly exempt from concurrency header requirements:

> *"The State Resource will permit PUT, POST and DELETE requests without concurrency headers, since state conflicts are unlikely."*

This meant that a second PUT to a state resource (overwriting an existing document) without concurrency headers would incorrectly return a `409 Conflict` instead of succeeding.

## Impact
_(since last LRSQL release)_

Articulate Storyline/Rise courses using `scormdriver.js` for xAPI communication do not send `If-Match` or `If-None-Match` headers when updating state documents. This caused state PUT requests to fail with `409 Conflict` when a state document already existed, breaking Articulate content playback and progress tracking.

## Changes

**`src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc`**

- Added state resource exemption: when `params-type` is `:xapi.activities.state.PUT.request/params`, PUTs without concurrency headers are allowed regardless of whether a document already exists

**`src/test/com/yetanalytics/lrs_test.clj`**

Added `document-concurrency-test` that validates version-aware concurrency behavior:

| Resource | Version | No existing doc | Existing doc (no headers) |
|---|---|---|---|
| State | 1.0.3 | 204 ✅ | 204 ✅ |
| State | 2.0.0 | 204 ✅ | 204 ✅ |