### PR TITLE
fix: handle precondition-failed error type in document PUT/POST responses

### DIFF
--- a/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
+++ b/src/main/com/yetanalytics/lrs/pedestal/routes/documents.cljc
@@ -237,7 +237,11 @@
 (defn put-response
   [ctx {:keys [error]}]
   (if error
-    (assoc ctx :io.pedestal.interceptor.chain/error error)
+    (let [exd (ex-data error)]
+      (if (#{:com.yetanalytics.lrs.xapi.document/precondition-failed}
+           (:type exd))
+        (assoc ctx :response {:status 412})
+        (assoc ctx :io.pedestal.interceptor.chain/error error)))
     (assoc ctx :response {:status 204})))
 
 
@@ -375,11 +379,18 @@
   [ctx {:keys [error] :as _lrs-response}]
   (if error
     (let [exd (ex-data error)]
-      (if (#{:com.yetanalytics.lrs.xapi.document/json-read-error
-             :com.yetanalytics.lrs.xapi.document/json-not-object-error
-             :com.yetanalytics.lrs.xapi.document/invalid-merge}
-           (:type exd))
+      (cond
+        (#{:com.yetanalytics.lrs.xapi.document/precondition-failed}
+         (:type exd))
+        (assoc ctx :response {:status 412})
+
+        (#{:com.yetanalytics.lrs.xapi.document/json-read-error
+           :com.yetanalytics.lrs.xapi.document/json-not-object-error
+           :com.yetanalytics.lrs.xapi.document/invalid-merge}
+         (:type exd))
         (assoc ctx :response {:status 400})
+
+        :else
         (assoc ctx :io.pedestal.interceptor.chain/error error)))
     (assoc ctx :response {:status 204})))
 


### PR DESCRIPTION
## Summary
- `put-response` and `post-response` in the document routes now handle `:com.yetanalytics.lrs.xapi.document/precondition-failed` errors by returning HTTP 412 (Precondition Failed)
- This enables downstream implementations (lrsql) to return structured error maps from `-set-document` when If-Match / If-None-Match validation fails, and have them correctly surfaced as 412 responses

## Context
The existing etag validation in `etags-preproc` runs in a separate interceptor stage before the actual document write. This creates a TOCTOU (Time-of-Check-Time-of-Use) race condition — between the etag check and the write, another request can modify the document, causing silent overwrites despite correct use of concurrency headers.

To fix this, the downstream LRS implementation needs to perform atomic check-then-write within a single DB transaction. This PR provides the error-handling plumbing so that a precondition failure detected at write time is correctly propagated as a 412.

## Changes
- `put-response`: Check `ex-data` for `::precondition-failed` type → 412
- `post-response`: Add `::precondition-failed` → 412 branch (using `cond` instead of nested `if` for clarity alongside existing 400 error types)

## Companion PR
Requires corresponding changes in lrsql (atomic etag validation in `-set-document`) to produce the `:com.yetanalytics.lrs.xapi.document/precondition-failed` error type:
https://github.com/yetanalytics/lrsql/pull/504

## Testing
Tested via lrsql `make test-sqlite`:
- xAPI 1.0.3 conformance: 1365/1365 passed
- xAPI 2.0.0 conformance: 1435/1435 passed
- Unit tests: 88 tests, 923 assertions, 0 failures, 0 errors
